### PR TITLE
Fix ClickGUI "Reset Positions" not toggling

### DIFF
--- a/src/main/kotlin/org/kamiblue/client/module/modules/client/ClickGUI.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/client/ClickGUI.kt
@@ -69,6 +69,7 @@ internal object ClickGUI : Module(
             KamiClickGui.windowList.forEach {
                 it.resetPosition()
             }
+            resetComponents.value = false
         }
     }
 


### PR DESCRIPTION
Before it would remain on and reset the position again when turned off.
