### PR TITLE
Fixed casing on my handle & uses Discord tag now

### DIFF
--- a/src/main/kotlin/com/lambda/client/gui/hudgui/elements/misc/Queue2B2T.kt
+++ b/src/main/kotlin/com/lambda/client/gui/hudgui/elements/misc/Queue2B2T.kt
@@ -78,7 +78,7 @@ internal object Queue2B2T : LabelHud(
 
     private fun sendWarning() {
         MessageSendHelper.sendWarningMessage(
-            "This module uses an external API, 2bqueue.info, which is operated by Tycrek at the time of writing." +
+            "This module uses an external API, 2bqueue.info, which is operated by tycrek#0001." +
                 "If you do not trust this external API / have not verified the safety yourself, disable this HUD component."
         )
         hasShownWarning.value = true


### PR DESCRIPTION
**Describe the pull**

Modified the "help text popup" (?) for Queue2b2t. I prefer my handle be lowercased and the Discord tag is good for a way to contact. Removed "at the time of writing" since I'm the only one who runs that project.

**Describe how this pull is helpful**

Because it matches my handle everywhere else and gives users a contact reference

Sorry for the random whitespace change at the end, GitHub's in-browser editor likes to do that a lot.