### PR TITLE
Updated Kotlin to 1.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,13 +26,6 @@ sourceSets.main.java {
     srcDirs += 'src/main/event'
 }
 
-compileKotlin {
-    kotlinOptions {
-        jvmTarget = "1.8"
-        useIR = true
-    }
-}
-
 compileJava {
     sourceCompatibility = targetCompatibility = '1.8'
     options.encoding = 'UTF-8'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.jvmargs=-Xmx3G
 modGroup=com.lambda
 modVersion=2.04.xx-dev
-kotlin_version=1.4.32
-kotlinx_coroutines_version=1.4.3
+kotlin_version=1.5.0
+kotlinx_coroutines_version=1.5.0-RC


### PR DESCRIPTION
https://kotlinlang.org/docs/releases.html#release-details

IR and JvmTarget 1.8 are default now so no longer need them in the build.gradle
https://kotlinlang.org/docs/whatsnew15.html#stable-jvm-ir-backend
https://kotlinlang.org/docs/whatsnew15.html#new-default-jvm-target-1-8