### PR TITLE
Add checksum generation to the workflow

### DIFF
--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -44,8 +44,8 @@ jobs :
       - name : Generate API mod checksum
         uses : ToxicAven/verify-file-checksum-action@master
         with :
-          fileUrl : lambda-${{ github.run_number }}-api.jar
-          saveFile : APISum.txt
+          fileUrl : ./lambda-${{ github.run_number }}-api.jar
+          saveFile : ./APISum.txt
           algorithm : SHA256
 
       - name : Archive plugin API
@@ -58,7 +58,7 @@ jobs :
         uses : actions/upload-artifact@v2
         with :
           name : APISum.txt
-          path : APISum.txt
+          path : ./APISum.txt
 
       - name : Get branch name
         uses: nelonoel/branch-name@v1.0.1

--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -35,38 +35,13 @@ jobs :
           restore-keys : |
             ${{ runner.os }}-gradle-
 
-      - name : Build forge mod
-        run : ./gradlew --build-cache build
-
-      - name: Rename built forge mod
-        run: mv build/libs/lambda-*.jar lambda-${{ github.run_number }}.jar
-
-      - name : Generate forge mod checksum
-        uses : ToxicAven/verify-file-checksum-action@master
-        with :
-          fileUrl : lambda-${{ github.run_number }}.jar
-          saveFile : forgeModSum.txt
-          algorithm : SHA256
-
-      - name : Archive forge mod
-        uses : actions/upload-artifact@v2
-        with :
-          name : lambda-${{ github.run_number }}
-          path : lambda-${{ github.run_number }}.jar
-
-      - name : Attempt to upload forge mod checksum
-        uses : actions/upload-artifact@v2
-        with :
-          name : forgeModSum.txt
-          path : forgeModSum.txt
-
       - name : Build plugin API
         run : ./gradlew apiJar
 
       - name: Rename built plugin API
         run: mv build/libs/lambda-*-api.jar lambda-${{ github.run_number }}-api.jar
 
-      - name : Generate forge mod checksum
+      - name : Generate API checksum
         uses : Argannor/checksum-action@master
         with :
           file : lambda-${{ github.run_number }}-api.jar
@@ -76,6 +51,12 @@ jobs :
         with :
           name : lambda-${{ github.run_number }}-api
           path : lambda-${{ github.run_number }}-api.jar
+
+      - name : Upload API checksum
+        uses : actions/upload-artifact@v2
+        with :
+          name : APISum.txt
+          path : APISum.txt
 
       - name : Get branch name
         uses: nelonoel/branch-name@v1.0.1

--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -41,10 +41,12 @@ jobs :
       - name: Rename built plugin API
         run: mv build/libs/lambda-*-api.jar lambda-${{ github.run_number }}-api.jar
 
-      - name : Generate API checksum
-        uses : Argannor/checksum-action@master
+      - name : Generate API mod checksum
+        uses : ToxicAven/verify-file-checksum-action@master
         with :
-          file : lambda-${{ github.run_number }}-api.jar
+          fileUrl : lambda-${{ github.run_number }}-api.jar
+          saveFile : APISum.txt
+          algorithm : SHA256
 
       - name : Archive plugin API
         uses : actions/upload-artifact@v2

--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -44,8 +44,8 @@ jobs :
       - name : Generate API mod checksum
         uses : ToxicAven/verify-file-checksum-action@master
         with :
-          fileUrl : ./lambda-${{ github.run_number }}-api.jar
-          saveFile : ./APISum.txt
+          filePath : lambda-${{ github.run_number }}-api.jar
+          saveFile : APISum.txt
           algorithm : SHA256
 
       - name : Archive plugin API
@@ -58,7 +58,7 @@ jobs :
         uses : actions/upload-artifact@v2
         with :
           name : APISum.txt
-          path : ./APISum.txt
+          path : APISum.txt
 
       - name : Get branch name
         uses: nelonoel/branch-name@v1.0.1

--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -44,7 +44,7 @@ jobs :
       - name : Generate forge mod checksum
         uses : ToxicAven/generate-checksum-file@v2
         with :
-          fileUrl : lambda-${{ github.run_number }}.jar
+          filePath : lambda-${{ github.run_number }}.jar
           saveFile : forgeModSum.txt
           algorithm : SHA256
 

--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -42,7 +42,7 @@ jobs :
         run: mv build/libs/lambda-*.jar lambda-${{ github.run_number }}.jar
 
       - name : Generate forge mod checksum
-        uses : ToxicAven/generate-checksum-file@v2
+        uses : ToxicAven/generate-checksum-file@v1
         with :
           filePath : lambda-${{ github.run_number }}.jar
           saveFile : forgeModSum.txt
@@ -67,7 +67,7 @@ jobs :
         run: mv build/libs/lambda-*-api.jar lambda-${{ github.run_number }}-api.jar
 
       - name : Generate API mod checksum
-        uses : ToxicAven/generate-checksum-file@v2
+        uses : ToxicAven/generate-checksum-file@v1
         with :
           filePath : lambda-${{ github.run_number }}-api.jar
           saveFile : APISum.txt

--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -41,6 +41,11 @@ jobs :
       - name: Rename built forge mod
         run: mv build/libs/lambda-*.jar lambda-${{ github.run_number }}.jar
 
+      - name : Generate forge mod checksum
+        uses : Argannor/checksum-action@master
+        with :
+          file : lambda-${{ github.run_number }}.jar
+
       - name : Archive forge mod
         uses : actions/upload-artifact@v2
         with :
@@ -52,6 +57,11 @@ jobs :
 
       - name: Rename built plugin API
         run: mv build/libs/lambda-*-api.jar lambda-${{ github.run_number }}-api.jar
+
+      - name : Generate forge mod checksum
+        uses : Argannor/checksum-action@master
+        with :
+          file : lambda-${{ github.run_number }}-api.jar
 
       - name : Archive plugin API
         uses : actions/upload-artifact@v2

--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -42,15 +42,23 @@ jobs :
         run: mv build/libs/lambda-*.jar lambda-${{ github.run_number }}.jar
 
       - name : Generate forge mod checksum
-        uses : Argannor/checksum-action@master
+        uses : ToxicAven/verify-file-checksum-action@master
         with :
-          file : lambda-${{ github.run_number }}.jar
+          fileUrl : lambda-${{ github.run_number }}.jar
+          saveFile : forgeModSum.txt
+          algorithm : SHA256
 
       - name : Archive forge mod
         uses : actions/upload-artifact@v2
         with :
           name : lambda-${{ github.run_number }}
           path : lambda-${{ github.run_number }}.jar
+
+      - name : Attempt to upload forge mod checksum
+        uses : actions/upload-artifact@v2
+        with :
+          name : forgeModSum.txt
+          path : forgeModSum.txt
 
       - name : Build plugin API
         run : ./gradlew apiJar

--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -35,6 +35,31 @@ jobs :
           restore-keys : |
             ${{ runner.os }}-gradle-
 
+      - name : Build forge mod
+        run : ./gradlew --build-cache build
+
+      - name: Rename built forge mod
+        run: mv build/libs/lambda-*.jar lambda-${{ github.run_number }}.jar
+
+      - name : Generate forge mod checksum
+        uses : ToxicAven/generate-checksum-file@v2
+        with :
+          fileUrl : lambda-${{ github.run_number }}.jar
+          saveFile : forgeModSum.txt
+          algorithm : SHA256
+
+      - name : Archive forge mod
+        uses : actions/upload-artifact@v2
+        with :
+          name : lambda-${{ github.run_number }}
+          path : lambda-${{ github.run_number }}.jar
+
+      - name : Archive forge mod checksum
+        uses : actions/upload-artifact@v2
+        with :
+          name : forgeModSum.txt
+          path : forgeModSum.txt
+
       - name : Build plugin API
         run : ./gradlew apiJar
 
@@ -42,7 +67,7 @@ jobs :
         run: mv build/libs/lambda-*-api.jar lambda-${{ github.run_number }}-api.jar
 
       - name : Generate API mod checksum
-        uses : ToxicAven/verify-file-checksum-action@master
+        uses : ToxicAven/generate-checksum-file@v2
         with :
           filePath : lambda-${{ github.run_number }}-api.jar
           saveFile : APISum.txt


### PR DESCRIPTION
There were no checksum generation actions, so I had to write an action for that. I can say firsthand, github actions are a pain.

[Source of action](https://github.com/ToxicAven/generate-checksum-file)
