### PR TITLE
Added a module removing all potential log4j and similar exploits

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/modules/chat/AntiChatExploit.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/chat/AntiChatExploit.kt
@@ -1,0 +1,59 @@
+package com.lambda.client.module.modules.chat
+
+import com.lambda.client.module.Category
+import com.lambda.client.module.Module
+import com.lambda.client.util.text.HarmfulFilters
+import com.lambda.event.listener.listener
+import net.minecraftforge.client.event.ClientChatReceivedEvent
+import java.util.concurrent.ConcurrentHashMap
+import java.util.regex.Pattern
+
+object AntiChatExploit : Module(
+    name = "AntiChatExploit",
+    category = Category.CHAT,
+    description = "Removes malicious patterns from the chat",
+    showOnArray = false
+) {
+    private val filterOwn by setting("Filter Own", false)
+
+
+    private val messageHistory = ConcurrentHashMap<String, Long>()
+
+    init {
+        onDisable {
+            messageHistory.clear()
+        }
+
+        listener<ClientChatReceivedEvent> { event ->
+            if (mc.player == null) return@listener
+
+            messageHistory.values.removeIf { System.currentTimeMillis() - it > 600000 }
+
+            val pattern = isHarmful(event.message.unformattedText)
+
+            pattern?.let {event.isCanceled = true }
+            }
+        }
+
+    private fun isHarmful(message: String): String? {
+        return if (!filterOwn && isOwn(message)) {
+            null
+        } else {
+            detectHarmfulMessages(message)
+        }
+    }
+
+    private fun detectHarmfulMessages(message: String): String? {
+        for (harmfulString in HarmfulFilters.harmfulStrings) {
+            if (message.contains(harmfulString)) {
+                return message
+            }
+        }
+        return null
+    }
+
+    private fun isOwn(message: String): Boolean {
+        val ownFilter = "^<" + mc.player.name + "> "
+        return Pattern.compile(ownFilter, Pattern.CASE_INSENSITIVE).matcher(message).find()
+    }
+}

--- a/src/main/kotlin/com/lambda/client/util/text/HarmfulFilters.kt
+++ b/src/main/kotlin/com/lambda/client/util/text/HarmfulFilters.kt
@@ -1,0 +1,6 @@
+package com.lambda.client.util.text;
+
+object HarmfulFilters {
+    val harmfulStrings = arrayOf(
+        "\${")
+}


### PR DESCRIPTION

**Describe the pull**
Removes all ${ from the chat (including names) in case the admin did not update the server and/or the user has an old forge version. 

**Describe how this pull is helpful**
 Removes all ${ from the chat and names. Will work for similar patterns. This method is used to protect servers, but not all servers are up to date. 
Any discovered patterns for workarounds could be added in the HarmfulFilters object if discovered 

**Additional context**
Added a module similar to spam but separate. Removes all ${ from the chat (including names) in case the admin did not update the server and/or the user has an old forge version. Simply removes everything with the harmful pattern. Designed the module in the way that it could be expanded in case other patterns would be discovered to be harmful in the future. 

Wrote this for myself but decided that other might find it useful.