### PR TITLE
Add AntiLevitation.kt fly mode

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/modules/movement/AntiLevitation.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/AntiLevitation.kt
@@ -66,15 +66,16 @@ object AntiLevitation : Module(
                 /* Makes the player fly and set the speed to the user's preference */
                 if (MovementUtils.isInputting && !vertical) {
                     val yaw = calcMoveYaw()
+                    player.isSprinting = false //disables sprinting so you can't go too fast
                     player.motionX = -sin(yaw) * speed
                     player.motionZ = cos(yaw) * speed
                 } else {
-                    player.motionX = 0.0
+                    /* Make the motion slowly become 0 so it looks smooth */
+                    player.motionX *= 0.85 //Possible memory leak? cuz it keeps making the number smaller i guess
                     player.motionY = 0.0
-                    player.motionZ = 0.0
+                    player.motionZ *= 0.85
                 }
                 //TODO: make it not flag when crouching
-                //TODO: disable sprinting
                 //TODO: find optimal speed that never flags
 
                 /* Apply Y motion the player wants to move to trick the anticheat */
@@ -83,8 +84,8 @@ object AntiLevitation : Module(
                 }
 
                 /* Vertical movement */
-                if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY = (speed / 1.1f).toDouble()
-                if (mc.gameSettings.keyBindSneak.isKeyDown) player.motionY = -(speed / 0.5f).toDouble() // You can go down way faster then going up
+                if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY = 0.145
+                if (mc.gameSettings.keyBindSneak.isKeyDown) player.motionY = -0.45 // You can go down way faster then going up
             }
         }
     }

--- a/src/main/kotlin/com/lambda/client/module/modules/movement/AntiLevitation.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/AntiLevitation.kt
@@ -112,7 +112,7 @@ object AntiLevitation : Module(
                     player.motionX = -sin(yaw) * 0.26
                     player.motionZ = cos(yaw) * 0.26
                 }
-            }
+            } else return@safeListener
         }
     }
 }

--- a/src/main/kotlin/com/lambda/client/module/modules/movement/AntiLevitation.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/AntiLevitation.kt
@@ -8,11 +8,11 @@ import com.lambda.client.module.Module
 import com.lambda.client.util.MovementUtils
 import com.lambda.client.util.MovementUtils.calcMoveYaw
 import com.lambda.client.util.MovementUtils.isMoving
+import com.lambda.client.util.MovementUtils.setSpeed
 import com.lambda.client.util.text.MessageSendHelper
 import com.lambda.client.util.threads.safeListener
 import net.minecraft.init.MobEffects
 import net.minecraftforge.fml.common.gameevent.TickEvent
-import org.lwjgl.input.Keyboard
 import kotlin.math.cos
 import kotlin.math.sin
 
@@ -25,7 +25,7 @@ object AntiLevitation : Module(
 
     /* Flight mode */
     private val vertical by setting("Only Vertical", false, { mode == Mode.FLIGHT }, description = "doesn't apply extra speed when enabled")
-    private val YMotion by setting("Motion UP", 0.002f, 0.0f..0.02f, 0.001f, { mode == Mode.FLIGHT }, description = "The Y Motion that is applied when moving to bypass the anticheat")
+    private val YMotion by setting("Y Motion", 0.002f, 0.0f..0.02f, 0.001f, { mode == Mode.FLIGHT }, description = "The Y Motion that is applied when moving to bypass the anticheat")
     private val speed by setting("Speed",  0.28f, 0.15f..0.3f, 0.005f, { !vertical && mode == Mode.FLIGHT }, description = "The speed you fly at")
     private val timer by setting("Timer Boost",  true, { !vertical && mode == Mode.FLIGHT }, description = "Use timer for a slight speed boost")
     private val timerSpeed by setting("Timer Speed",  1.15f, 1.1f..1.2f, 0.01f, { timer && !vertical && mode == Mode.FLIGHT }, description = "The timer modifier")
@@ -33,6 +33,9 @@ object AntiLevitation : Module(
     /* Legit mode */
     private val LegitYMotion by setting("Motion UP", 0.018f, 0.001f..0.1f, 0.001f, { mode == Mode.LEGIT }, description = "The Y Motion that is applied when moving to bypass the anticheat")
     private val boost by setting("Sprint Boost", true, { mode == Mode.LEGIT }, description = "Gives you extra motion when control is pressed")
+
+    /* Jump motion (used by flight mode and legit mode) */
+    private val jumpMotion by setting("Jump Motion", 0.099f, 0.090f..0.10f, 0.001f, { mode == Mode.FLIGHT || mode == Mode.LEGIT}, description = "The Y Motion that is applied when you press space")
 
     private var ready = false
     private var legitReady = false
@@ -44,75 +47,63 @@ object AntiLevitation : Module(
     init {
         onDisable {
             ready = false
-            legitReady = false
             resetTimer()
         }
 
         safeListener<TickEvent.ClientTickEvent> {
             if (player.isPotionActive(MobEffects.LEVITATION)) {
-                if (mode == Mode.FLIGHT) {
-                    if (!ready) MessageSendHelper.sendChatMessage("You can now fly.")
+                if (mode != Mode.REMOVE && !ready) {
                     ready = true
-                } else if (mode == Mode.LEGIT){
-                    legitReady = true
-                } else {
+                    MessageSendHelper.sendChatMessage("You can now fly.")
+                }
+                if (mode == Mode.REMOVE) {
                     player.removeActivePotionEffect(MobEffects.LEVITATION)
                     MessageSendHelper.sendChatMessage("Removed levitation effect.")
                 }
             } else {
-                if (mode == Mode.FLIGHT && ready || mode == Mode.LEGIT && legitReady) {
+                if (ready) {
                     resetTimer()
+                    MessageSendHelper.sendWarningMessage("Levitation ran out. Brace for impact....")
+                    mc.player.setVelocity(0.0,0.0,0.0)
                     ready = false
-                    legitReady = false
-                    MessageSendHelper.sendChatMessage("Levitation ran out. Brace for impact....")
-                    mc.player.setVelocity(0.0,0.0,0.0) //Reset velocity to make anticheat glitch out less
                 }
             }
         }
 
         safeListener<PlayerTravelEvent> {
             if (ready) {
-                if (MovementUtils.isInputting && !vertical) {
-                    /* Makes the player move when they press a movement key */
-                    val yaw = calcMoveYaw()
-                    player.isSprinting = false //disables sprinting so you can't go too fast
-                    player.motionX = -sin(yaw) * speed
-                    player.motionZ = cos(yaw) * speed
-                    if (timer && !vertical) modifyTimer(50.0f / timerSpeed)
+                if (mode == Mode.FLIGHT) {
+                    if (MovementUtils.isInputting && !vertical) {
+                        player.isSprinting = false //disables sprinting so you can't go too fast
+                        setSpeed(speed.toDouble())
+                        if (timer && !vertical) modifyTimer(50.0f / timerSpeed)
+                    } else {
+                        player.motionY = 0.0
+                        /* Make the motion slowly become 0 so it flattens out smooth */
+                        player.motionX *= 0.8
+                        player.motionZ *= 0.8
+                    }
 
-                } else {
-                    player.motionY = 0.0 // Makes the Y motion always be 0.0 when not pressing any key so you can stand still in the air
+                    if (MovementUtils.isInputting || player.isMoving) {
+                        player.motionY = YMotion.toDouble()
+                    }
 
-                    /* Make the motion slowly become 0 so it flattens out smooth */
-                    player.motionX *= 0.8 // Possible memory leak? cuz it keeps making the number smaller i guess
-                    player.motionZ *= 0.8
+                    if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY = jumpMotion.toDouble()
+                    if (mc.gameSettings.keyBindSneak.isKeyDown) player.motionY = -0.49
+                } else if (mode == Mode.LEGIT) {
+                    /* Override vanilla motion with our own motion */
+                    player.motionY = LegitYMotion.toDouble()
+
+                    if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY = jumpMotion.toDouble()
+                    if (mc.gameSettings.keyBindSneak.isKeyDown) player.motionY = 0.005
+
+                    if (mc.gameSettings.keyBindSprint.isKeyDown && player.isSprinting && boost) { //player must be sprinting so you can only boost when you press W
+                        val yaw = calcMoveYaw()
+                        player.motionX = -sin(yaw) * 0.26
+                        player.motionZ = cos(yaw) * 0.26
+                    }
                 }
-
-                /* Apply tiny Y motion when the player wants to move to trick the anticheat */
-                if (MovementUtils.isInputting || player.isMoving) {
-                    player.motionY = YMotion.toDouble()
-                }
-
-                /* Vertical movement */
-                if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY = 0.0925
-                if (mc.gameSettings.keyBindSneak.isKeyDown) player.motionY = -0.49 // You can go down way faster then going up for some reason
-            } else if (legitReady) {
-                /* Override vanilla motion with our own motion */
-                player.motionY = LegitYMotion.toDouble()
-
-                /* Jump boost */
-                if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY = 0.0875
-
-                /* Shift slow down */
-                if (mc.gameSettings.keyBindSneak.isKeyDown) player.motionY = 0.005
-
-                /* Slight boost when control is pressed */
-                if (Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) && player.isSprinting && boost) { //player also must be sprinting so you can only boost when you press W
-                    val yaw = calcMoveYaw()
-                    player.motionX = -sin(yaw) * 0.26
-                    player.motionZ = cos(yaw) * 0.26
-                }
-            } else return@safeListener
+            }
         }
     }
 }

--- a/src/main/kotlin/com/lambda/client/module/modules/movement/AntiLevitation.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/AntiLevitation.kt
@@ -92,14 +92,14 @@ object AntiLevitation : Module(
                 }
 
                 /* Vertical movement */
-                if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY = 0.145
+                if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY = 0.1
                 if (mc.gameSettings.keyBindSneak.isKeyDown) player.motionY = -0.49 // You can go down way faster then going up for some reason
             } else if (legitReady) {
                 /* Override vanilla motion with our own motion */
                 player.motionY = LegitYMotion.toDouble()
 
                 /* Jump boost */
-                if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY += 0.1
+                if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY = 0.0875
 
                 /* Shift slow down */
                 if (mc.gameSettings.keyBindSneak.isKeyDown) player.motionY = 0.005

--- a/src/main/kotlin/com/lambda/client/module/modules/movement/AntiLevitation.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/AntiLevitation.kt
@@ -1,13 +1,14 @@
 package com.lambda.client.module.modules.movement
 
 import com.lambda.client.event.events.PlayerTravelEvent
+import com.lambda.client.manager.managers.TimerManager.modifyTimer
+import com.lambda.client.manager.managers.TimerManager.resetTimer
 import com.lambda.client.module.Category
 import com.lambda.client.module.Module
 import com.lambda.client.util.MovementUtils
 import com.lambda.client.util.MovementUtils.calcMoveYaw
 import com.lambda.client.util.MovementUtils.isMoving
 import com.lambda.client.util.text.MessageSendHelper
-import com.lambda.client.util.threads.runSafe
 import com.lambda.client.util.threads.safeListener
 import net.minecraft.init.MobEffects
 import net.minecraftforge.fml.common.gameevent.TickEvent
@@ -16,32 +17,29 @@ import kotlin.math.sin
 
 object AntiLevitation : Module(
     name = "AntiLevitation",
-    description = "Removes levitation potion effect (boring) or abuse it (epic)",
+    description = "Removes levitation effect (boring) or abuse it (epic)",
     category = Category.MOVEMENT
 ) {
+    //TODO: Make it a mode instead of an option + add a legit mode
     private val fly by setting("Fly", true, description = "Allows you to \"fly\" when you have levitation")
     private val vertical by setting("Only Vertical", false, { fly }, description = "doesn't apply extra speed when enabled")
-    private val YMotion by setting("Constant Motion UP", 0.002f, 0.0f..0.02f, 0.001f, { fly }, description = "The Y Motion that is always applied to bypass the anticheat")
-    private val speed by setting("Speed",  0.28f, 0.15f..0.3f, 0.005f, { fly }, description = "The speed you fly at")
+    private val YMotion by setting("Motion UP", 0.002f, 0.0f..0.02f, 0.001f, { fly }, description = "The Y Motion that is applied when moving to bypass the anticheat")
+    private val speed by setting("Speed",  0.28f, 0.15f..0.3f, 0.005f, { !vertical && fly }, description = "The speed you fly at")
+    private val timer by setting("Timer Boost",  true, { !vertical && fly }, description = "Use timer for a slight speed boost")
+    private val timerSpeed by setting("Timer Speed",  1.15f, 1.1f..1.2f, 0.01f, { timer && !vertical && fly }, description = "The timer modifier")
 
     private var ready = false
 
     init {
         onDisable {
             ready = false
-            if (fly) {
-                runSafe {
-                    player.capabilities?.apply {
-                        isFlying = false
-                        flySpeed = 0.05f
-                    }
-                }
-            }
+            resetTimer()
         }
 
         safeListener<TickEvent.ClientTickEvent> {
             if (player.isPotionActive(MobEffects.LEVITATION)) {
                 if (fly) {
+                    if (!ready) MessageSendHelper.sendChatMessage("You can now fly.")
                     ready = true
                 } else {
                     player.removeActivePotionEffect(MobEffects.LEVITATION)
@@ -49,12 +47,6 @@ object AntiLevitation : Module(
                 }
             } else {
                 if (fly && ready) {
-                    runSafe {
-                        player.capabilities?.apply {
-                            isFlying = false
-                            flySpeed = 0.05f
-                        }
-                    }
                     MessageSendHelper.sendChatMessage("Levitation ran out. Brace for impact....")
                     ready = false
                 }
@@ -63,29 +55,29 @@ object AntiLevitation : Module(
 
         safeListener<PlayerTravelEvent> {
             if (ready) {
-                /* Makes the player fly and set the speed to the user's preference */
                 if (MovementUtils.isInputting && !vertical) {
+                    /* Makes the player move when they press a movement key */
                     val yaw = calcMoveYaw()
                     player.isSprinting = false //disables sprinting so you can't go too fast
                     player.motionX = -sin(yaw) * speed
                     player.motionZ = cos(yaw) * speed
+                    if (timer && !vertical) modifyTimer(50.0f / timerSpeed)
                 } else {
-                    /* Make the motion slowly become 0 so it looks smooth */
-                    player.motionX *= 0.85 //Possible memory leak? cuz it keeps making the number smaller i guess
-                    player.motionY = 0.0
+                    player.motionY = 0.0 // Makes the Y motion always be 0.0 when not pressing any key so levitation doesn't work
+
+                    /* Make the motion slowly become 0 so it flattens out smooth */
+                    player.motionX *= 0.85 // Possible memory leak? cuz it keeps making the number smaller i guess
                     player.motionZ *= 0.85
                 }
-                //TODO: make it not flag when crouching
-                //TODO: find optimal speed that never flags
 
-                /* Apply Y motion the player wants to move to trick the anticheat */
+                /* Apply tiny Y motion when the player wants to move to trick the anticheat */
                 if (MovementUtils.isInputting || player.isMoving) {
                     player.motionY = YMotion.toDouble()
                 }
 
                 /* Vertical movement */
                 if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY = 0.145
-                if (mc.gameSettings.keyBindSneak.isKeyDown) player.motionY = -0.45 // You can go down way faster then going up
+                if (mc.gameSettings.keyBindSneak.isKeyDown) player.motionY = -0.49 // You can go down way faster then going up for some reason
             }
         }
     }

--- a/src/main/kotlin/com/lambda/client/module/modules/movement/AntiLevitation.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/AntiLevitation.kt
@@ -1,20 +1,77 @@
 package com.lambda.client.module.modules.movement
 
+import com.lambda.client.event.events.PlayerTravelEvent
 import com.lambda.client.module.Category
 import com.lambda.client.module.Module
+import com.lambda.client.util.MovementUtils
+import com.lambda.client.util.MovementUtils.isMoving
+import com.lambda.client.util.text.MessageSendHelper
+import com.lambda.client.util.threads.runSafe
 import com.lambda.client.util.threads.safeListener
 import net.minecraft.init.MobEffects
 import net.minecraftforge.fml.common.gameevent.TickEvent
 
 object AntiLevitation : Module(
     name = "AntiLevitation",
-    description = "Removes levitation potion effect",
+    description = "Removes levitation potion effect (boring) or abuse it (epic)",
     category = Category.MOVEMENT
 ) {
+    private val fly by setting("Fly", true, description = "Allows you to \"fly\" when you have levitation")
+    private val vertical by setting("Only Vertical", false, { fly }, description = "doesn't apply extra speed when enabled")
+    private val YMotion by setting("Constant Motion UP", 0.002f, 0.0f..0.02f, 0.001f, { fly }, description = "The Y Motion that is always applied to bypass the anticheat")
+    private val speed by setting("Speed",  0.15f, 0.01f..0.2f, 0.005f, { fly }, description = "The speed you fly at")
+
+    private var ready = false
+
     init {
+        onDisable {
+            ready = false
+            if (fly) {
+                runSafe {
+                    player.capabilities?.apply {
+                        isFlying = false
+                        flySpeed = 0.05f
+                    }
+                }
+            }
+        }
+
         safeListener<TickEvent.ClientTickEvent> {
             if (player.isPotionActive(MobEffects.LEVITATION)) {
-                player.removeActivePotionEffect(MobEffects.LEVITATION)
+                if (fly) {
+                    ready = true
+                } else {
+                    player.removeActivePotionEffect(MobEffects.LEVITATION)
+                    MessageSendHelper.sendChatMessage("Removed levitation effect.")
+                }
+            } else {
+                if (fly && ready) {
+                    runSafe {
+                        player.capabilities?.apply {
+                            isFlying = false
+                            flySpeed = 0.05f
+                        }
+                    }
+                    MessageSendHelper.sendChatMessage("Levitation ran out. Brace for impact....")
+                    ready = false
+                }
+            }
+        }
+
+        safeListener<PlayerTravelEvent> {
+            if (ready) {
+                /* Makes the player fly and set the speed to the user's preference */
+                if (!vertical) player.capabilities.isFlying = true
+                if (!vertical) player.capabilities.flySpeed = speed / 11.11f
+
+                /* Apply Y motion the player wants to move to trick the anticheat */
+                if (MovementUtils.isInputting || player.isMoving) {
+                    player.motionY = YMotion.toDouble()
+                }
+
+                /* Vertical movement */
+                if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY = (speed / 1.1f).toDouble()
+                if (mc.gameSettings.keyBindSneak.isKeyDown) player.motionY = -(speed / 0.5f).toDouble() // You can go down way faster then going up
             }
         }
     }

--- a/src/main/kotlin/com/lambda/client/module/modules/movement/AntiLevitation.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/AntiLevitation.kt
@@ -61,9 +61,11 @@ object AntiLevitation : Module(
                 }
             } else {
                 if (mode == Mode.FLIGHT && ready || mode == Mode.LEGIT && legitReady) {
-                    MessageSendHelper.sendChatMessage("Levitation ran out. Brace for impact....")
+                    resetTimer()
                     ready = false
                     legitReady = false
+                    MessageSendHelper.sendChatMessage("Levitation ran out. Brace for impact....")
+                    mc.player.setVelocity(0.0,0.0,0.0) //Reset velocity to make anticheat glitch out less
                 }
             }
         }
@@ -82,8 +84,8 @@ object AntiLevitation : Module(
                     player.motionY = 0.0 // Makes the Y motion always be 0.0 when not pressing any key so you can stand still in the air
 
                     /* Make the motion slowly become 0 so it flattens out smooth */
-                    player.motionX *= 0.85 // Possible memory leak? cuz it keeps making the number smaller i guess
-                    player.motionZ *= 0.85
+                    player.motionX *= 0.8 // Possible memory leak? cuz it keeps making the number smaller i guess
+                    player.motionZ *= 0.8
                 }
 
                 /* Apply tiny Y motion when the player wants to move to trick the anticheat */
@@ -92,7 +94,7 @@ object AntiLevitation : Module(
                 }
 
                 /* Vertical movement */
-                if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY = 0.1
+                if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY = 0.0925
                 if (mc.gameSettings.keyBindSneak.isKeyDown) player.motionY = -0.49 // You can go down way faster then going up for some reason
             } else if (legitReady) {
                 /* Override vanilla motion with our own motion */

--- a/src/main/kotlin/com/lambda/client/module/modules/movement/AntiLevitation.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/AntiLevitation.kt
@@ -12,6 +12,7 @@ import com.lambda.client.util.text.MessageSendHelper
 import com.lambda.client.util.threads.safeListener
 import net.minecraft.init.MobEffects
 import net.minecraftforge.fml.common.gameevent.TickEvent
+import org.lwjgl.input.Keyboard
 import kotlin.math.cos
 import kotlin.math.sin
 
@@ -20,35 +21,49 @@ object AntiLevitation : Module(
     description = "Removes levitation effect (boring) or abuse it (epic)",
     category = Category.MOVEMENT
 ) {
-    //TODO: Make it a mode instead of an option + add a legit mode
-    private val fly by setting("Fly", true, description = "Allows you to \"fly\" when you have levitation")
-    private val vertical by setting("Only Vertical", false, { fly }, description = "doesn't apply extra speed when enabled")
-    private val YMotion by setting("Motion UP", 0.002f, 0.0f..0.02f, 0.001f, { fly }, description = "The Y Motion that is applied when moving to bypass the anticheat")
-    private val speed by setting("Speed",  0.28f, 0.15f..0.3f, 0.005f, { !vertical && fly }, description = "The speed you fly at")
-    private val timer by setting("Timer Boost",  true, { !vertical && fly }, description = "Use timer for a slight speed boost")
-    private val timerSpeed by setting("Timer Speed",  1.15f, 1.1f..1.2f, 0.01f, { timer && !vertical && fly }, description = "The timer modifier")
+    private val mode by setting("Mode", Mode.LEGIT, description = "The AntiLevitation mode")
+
+    /* Flight mode */
+    private val vertical by setting("Only Vertical", false, { mode == Mode.FLIGHT }, description = "doesn't apply extra speed when enabled")
+    private val YMotion by setting("Motion UP", 0.002f, 0.0f..0.02f, 0.001f, { mode == Mode.FLIGHT }, description = "The Y Motion that is applied when moving to bypass the anticheat")
+    private val speed by setting("Speed",  0.28f, 0.15f..0.3f, 0.005f, { !vertical && mode == Mode.FLIGHT }, description = "The speed you fly at")
+    private val timer by setting("Timer Boost",  true, { !vertical && mode == Mode.FLIGHT }, description = "Use timer for a slight speed boost")
+    private val timerSpeed by setting("Timer Speed",  1.15f, 1.1f..1.2f, 0.01f, { timer && !vertical && mode == Mode.FLIGHT }, description = "The timer modifier")
+
+    /* Legit mode */
+    private val LegitYMotion by setting("Motion UP", 0.018f, 0.001f..0.1f, 0.001f, { mode == Mode.LEGIT }, description = "The Y Motion that is applied when moving to bypass the anticheat")
+    private val boost by setting("Sprint Boost", true, { mode == Mode.LEGIT }, description = "Gives you extra motion when control is pressed")
 
     private var ready = false
+    private var legitReady = false
+
+    private enum class Mode {
+        REMOVE, FLIGHT, LEGIT
+    }
 
     init {
         onDisable {
             ready = false
+            legitReady = false
             resetTimer()
         }
 
         safeListener<TickEvent.ClientTickEvent> {
             if (player.isPotionActive(MobEffects.LEVITATION)) {
-                if (fly) {
+                if (mode == Mode.FLIGHT) {
                     if (!ready) MessageSendHelper.sendChatMessage("You can now fly.")
                     ready = true
+                } else if (mode == Mode.LEGIT){
+                    legitReady = true
                 } else {
                     player.removeActivePotionEffect(MobEffects.LEVITATION)
                     MessageSendHelper.sendChatMessage("Removed levitation effect.")
                 }
             } else {
-                if (fly && ready) {
+                if (mode == Mode.FLIGHT && ready || mode == Mode.LEGIT && legitReady) {
                     MessageSendHelper.sendChatMessage("Levitation ran out. Brace for impact....")
                     ready = false
+                    legitReady = false
                 }
             }
         }
@@ -62,8 +77,9 @@ object AntiLevitation : Module(
                     player.motionX = -sin(yaw) * speed
                     player.motionZ = cos(yaw) * speed
                     if (timer && !vertical) modifyTimer(50.0f / timerSpeed)
+
                 } else {
-                    player.motionY = 0.0 // Makes the Y motion always be 0.0 when not pressing any key so levitation doesn't work
+                    player.motionY = 0.0 // Makes the Y motion always be 0.0 when not pressing any key so you can stand still in the air
 
                     /* Make the motion slowly become 0 so it flattens out smooth */
                     player.motionX *= 0.85 // Possible memory leak? cuz it keeps making the number smaller i guess
@@ -78,6 +94,22 @@ object AntiLevitation : Module(
                 /* Vertical movement */
                 if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY = 0.145
                 if (mc.gameSettings.keyBindSneak.isKeyDown) player.motionY = -0.49 // You can go down way faster then going up for some reason
+            } else if (legitReady) {
+                /* Override vanilla motion with our own motion */
+                player.motionY = LegitYMotion.toDouble()
+
+                /* Jump boost */
+                if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY += 0.1
+
+                /* Shift slow down */
+                if (mc.gameSettings.keyBindSneak.isKeyDown) player.motionY = 0.005
+
+                /* Slight boost when control is pressed */
+                if (Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) && player.isSprinting && boost) { //player also must be sprinting so you can only boost when you press W
+                    val yaw = calcMoveYaw()
+                    player.motionX = -sin(yaw) * 0.26
+                    player.motionZ = cos(yaw) * 0.26
+                }
             }
         }
     }

--- a/src/main/kotlin/com/lambda/client/module/modules/movement/AntiLevitation.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/AntiLevitation.kt
@@ -25,20 +25,19 @@ object AntiLevitation : Module(
 
     /* Flight mode */
     private val vertical by setting("Only Vertical", false, { mode == Mode.FLIGHT }, description = "doesn't apply extra speed when enabled")
-    private val YMotion by setting("Y Motion", 0.002f, 0.0f..0.02f, 0.001f, { mode == Mode.FLIGHT }, description = "The Y Motion that is applied when moving to bypass the anticheat")
-    private val speed by setting("Speed",  0.28f, 0.15f..0.3f, 0.005f, { !vertical && mode == Mode.FLIGHT }, description = "The speed you fly at")
-    private val timer by setting("Timer Boost",  true, { !vertical && mode == Mode.FLIGHT }, description = "Use timer for a slight speed boost")
-    private val timerSpeed by setting("Timer Speed",  1.15f, 1.1f..1.2f, 0.01f, { timer && !vertical && mode == Mode.FLIGHT }, description = "The timer modifier")
+    private val yMotion by setting("Y Motion", 0.002f, 0.0f..0.02f, 0.001f, { mode == Mode.FLIGHT }, description = "The Y Motion that is applied when moving to bypass the anticheat")
+    private val speed by setting("Speed", 0.28f, 0.15f..0.3f, 0.005f, { !vertical && mode == Mode.FLIGHT }, description = "The speed you fly at")
+    private val timer by setting("Timer Boost", true, { !vertical && mode == Mode.FLIGHT }, description = "Use timer for a slight speed boost")
+    private val timerSpeed by setting("Timer Speed", 1.15f, 1.1f..1.2f, 0.01f, { timer && !vertical && mode == Mode.FLIGHT }, description = "The timer modifier")
 
     /* Legit mode */
-    private val LegitYMotion by setting("Motion UP", 0.018f, 0.001f..0.1f, 0.001f, { mode == Mode.LEGIT }, description = "The Y Motion that is applied when moving to bypass the anticheat")
+    private val legitYMotion by setting("Motion Up", 0.018f, 0.001f..0.1f, 0.001f, { mode == Mode.LEGIT }, description = "The Y Motion that is applied when moving to bypass the anticheat")
     private val boost by setting("Sprint Boost", true, { mode == Mode.LEGIT }, description = "Gives you extra motion when control is pressed")
 
     /* Jump motion (used by flight mode and legit mode) */
-    private val jumpMotion by setting("Jump Motion", 0.099f, 0.090f..0.10f, 0.001f, { mode == Mode.FLIGHT || mode == Mode.LEGIT}, description = "The Y Motion that is applied when you press space")
+    private val jumpMotion by setting("Jump Motion", 0.099f, 0.090f..0.10f, 0.001f, { mode == Mode.FLIGHT || mode == Mode.LEGIT }, description = "The Y Motion that is applied when you press space")
 
     private var ready = false
-    private var legitReady = false
 
     private enum class Mode {
         REMOVE, FLIGHT, LEGIT
@@ -64,44 +63,44 @@ object AntiLevitation : Module(
                 if (ready) {
                     resetTimer()
                     MessageSendHelper.sendWarningMessage("Levitation ran out. Brace for impact....")
-                    mc.player.setVelocity(0.0,0.0,0.0)
+                    player.setVelocity(0.0, 0.0, 0.0)
                     ready = false
                 }
             }
         }
 
         safeListener<PlayerTravelEvent> {
-            if (ready) {
-                if (mode == Mode.FLIGHT) {
-                    if (MovementUtils.isInputting && !vertical) {
-                        player.isSprinting = false //disables sprinting so you can't go too fast
-                        setSpeed(speed.toDouble())
-                        if (timer && !vertical) modifyTimer(50.0f / timerSpeed)
-                    } else {
-                        player.motionY = 0.0
-                        /* Make the motion slowly become 0 so it flattens out smooth */
-                        player.motionX *= 0.8
-                        player.motionZ *= 0.8
-                    }
+            if (!ready) return@safeListener
 
-                    if (MovementUtils.isInputting || player.isMoving) {
-                        player.motionY = YMotion.toDouble()
-                    }
+            if (mode == Mode.FLIGHT) {
+                if (MovementUtils.isInputting && !vertical) {
+                    player.isSprinting = false //disables sprinting so you can't go too fast
+                    setSpeed(speed.toDouble())
+                    if (timer && !vertical) modifyTimer(50.0f / timerSpeed)
+                } else {
+                    player.motionY = 0.0
+                    /* Make the motion slowly become 0, so it flattens out smooth */
+                    player.motionX *= 0.8
+                    player.motionZ *= 0.8
+                }
 
-                    if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY = jumpMotion.toDouble()
-                    if (mc.gameSettings.keyBindSneak.isKeyDown) player.motionY = -0.49
-                } else if (mode == Mode.LEGIT) {
-                    /* Override vanilla motion with our own motion */
-                    player.motionY = LegitYMotion.toDouble()
+                if (MovementUtils.isInputting || player.isMoving) {
+                    player.motionY = yMotion.toDouble()
+                }
 
-                    if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY = jumpMotion.toDouble()
-                    if (mc.gameSettings.keyBindSneak.isKeyDown) player.motionY = 0.005
+                if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY = jumpMotion.toDouble()
+                if (mc.gameSettings.keyBindSneak.isKeyDown) player.motionY = -0.49
+            } else if (mode == Mode.LEGIT) {
+                /* Override vanilla motion with our own motion */
+                player.motionY = legitYMotion.toDouble()
 
-                    if (mc.gameSettings.keyBindSprint.isKeyDown && player.isSprinting && boost) { //player must be sprinting so you can only boost when you press W
-                        val yaw = calcMoveYaw()
-                        player.motionX = -sin(yaw) * 0.26
-                        player.motionZ = cos(yaw) * 0.26
-                    }
+                if (mc.gameSettings.keyBindJump.isKeyDown) player.motionY = jumpMotion.toDouble()
+                if (mc.gameSettings.keyBindSneak.isKeyDown) player.motionY = 0.005
+
+                if (mc.gameSettings.keyBindSprint.isKeyDown && player.isSprinting && boost) { //player must be sprinting so you can only boost when you press W
+                    val yaw = calcMoveYaw()
+                    player.motionX = -sin(yaw) * 0.26
+                    player.motionZ = cos(yaw) * 0.26
                 }
             }
         }


### PR DESCRIPTION
It allows you to fly when the player has the Levitation effect. The default config is optimized to work with the default updated-NCP config.

When standing still in the air the head rotation is kind of buggy, because Y motion is not applied.

~~TODO: use motion instead of capabilities fly~~