### PR TITLE
added WorldEvent listener to ForgeEventProcessor.kt

### DIFF
--- a/src/main/kotlin/com/lambda/client/event/ForgeEventProcessor.kt
+++ b/src/main/kotlin/com/lambda/client/event/ForgeEventProcessor.kt
@@ -14,7 +14,7 @@ import com.lambda.client.util.text.MessageDetection
 import net.minecraftforge.client.event.*
 import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent
 import net.minecraftforge.event.entity.player.PlayerInteractEvent
-import net.minecraftforge.event.world.ChunkEvent
+import net.minecraftforge.event.world.WorldEvent
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import net.minecraftforge.fml.common.gameevent.InputEvent
@@ -98,8 +98,11 @@ internal object ForgeEventProcessor {
         LambdaEventBus.post(event)
     }
 
+    /**
+     * Includes events of subclasses like ChunkEvent, ChunkDataEvent, BlockEvent, NoteBlockEvent, GetCollisionBoxesEvent
+     */
     @SubscribeEvent
-    fun onChunkLoaded(event: ChunkEvent.Unload) {
+    fun onWorldEvent(event: WorldEvent) {
         LambdaEventBus.post(event)
     }
 


### PR DESCRIPTION
**Describe the pull**
ForgeEventProcessor.kt will forward every WorldEvent and the respective subclass-events to the LambdaEventBus.
The listener for ChunkEvent.Unload must be removed since it extends WorldEvent and thus will be forwarded by its listener.

**Describe how this pull is helpful**
WorldEvent and its subclasses include a bunch of useful events like ChunkEvent, ChunkDataEvent, BlockEvent, NoteBlockEvent, GetCollisionBoxesEvent. Just adding the listener for WorldEvent instead of all subclasses individually saves a lot of code lines and works just as well with the listeners inside the modules (I tested that). I also made sure to check if there are any other listeners in the ForgeEventProcessor that might inherit from WorldEvent and thus would fire twice. But there are none except for ChunkEvent.Unload.
The reason I want to have this event on the bus is because I need to listen for WorldEvent, ChunkEvent and NoteBlockEvent for a plugin I am working on right now.

If you have any questions, please feel free to contact me here or on Discord: Simon#4530
Thank you very much!
