### PR TITLE
Added NoGhostItems. Makes sure item transactions got accepted before doing client side inventory change

### DIFF
--- a/src/main/java/com/lambda/mixin/player/MixinPlayerControllerMP.java
+++ b/src/main/java/com/lambda/mixin/player/MixinPlayerControllerMP.java
@@ -2,12 +2,15 @@ package com.lambda.mixin.player;
 
 import com.lambda.client.event.LambdaEventBus;
 import com.lambda.client.event.events.PlayerAttackEvent;
+import com.lambda.client.module.modules.player.NoGhostItems;
 import com.lambda.client.module.modules.player.TpsSync;
 import com.lambda.client.util.TpsCalculator;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.multiplayer.PlayerControllerMP;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.ClickType;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
@@ -15,6 +18,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(PlayerControllerMP.class)
 public class MixinPlayerControllerMP {
@@ -31,6 +35,14 @@ public class MixinPlayerControllerMP {
         LambdaEventBus.INSTANCE.post(event);
         if (event.getCancelled()) {
             ci.cancel();
+        }
+    }
+
+    @Inject(method = "windowClick", at = @At("HEAD"), cancellable = true)
+    public void onWindowClick(int windowId, int slotId, int mouseButton, ClickType type, EntityPlayer player, CallbackInfoReturnable<ItemStack> cir) {
+        if (NoGhostItems.INSTANCE.isEnabled()) {
+            NoGhostItems.INSTANCE.handleWindowClick(windowId, slotId, mouseButton, type, player);
+            cir.cancel();
         }
     }
 }

--- a/src/main/kotlin/com/lambda/client/module/modules/player/NoGhostItems.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/player/NoGhostItems.kt
@@ -1,0 +1,54 @@
+package com.lambda.client.module.modules.player
+
+import com.lambda.client.LambdaMod
+import com.lambda.client.event.events.PacketEvent
+import com.lambda.client.event.listener.listener
+import com.lambda.client.module.Category
+import com.lambda.client.module.Module
+import com.lambda.client.util.threads.runSafe
+import net.minecraft.entity.player.EntityPlayer
+import net.minecraft.inventory.ClickType
+import net.minecraft.item.ItemStack
+import net.minecraft.network.play.client.CPacketClickWindow
+import net.minecraft.network.play.server.SPacketConfirmTransaction
+import java.util.concurrent.ConcurrentHashMap
+
+object NoGhostItems : Module(
+    name = "NoGhostItems",
+    description = "Syncs inventory transactions for strict environments",
+    category = Category.PLAYER
+) {
+    private val pendingTransactions = ConcurrentHashMap<Short, InventoryTransaction>()
+
+    init {
+        listener<PacketEvent.Receive> { event ->
+            if (event.packet is SPacketConfirmTransaction) {
+                pendingTransactions[event.packet.actionNumber]?.let {
+                    it.player.openContainer.slotClick(it.slotId, it.mouseButton, it.type, it.player)
+                    pendingTransactions.remove(event.packet.actionNumber)
+                    LambdaMod.LOG.info("Accepted transaction: ${event.packet.actionNumber}")
+                }
+            }
+        }
+    }
+
+    fun handleWindowClick(windowId: Int, slotId: Int, mouseButton: Int, type: ClickType, player: EntityPlayer) {
+        val transaction = InventoryTransaction(windowId, slotId, mouseButton, type, player)
+
+        if (!pendingTransactions.values.contains(transaction)) {
+            val transactionID = transaction.player.openContainer.getNextTransactionID(transaction.player.inventory)
+            pendingTransactions[transactionID] = transaction
+
+            LambdaMod.LOG.info("Started transaction: transactionID: $transactionID transaction: $transaction")
+            runSafe {
+                connection.sendPacket(CPacketClickWindow(transaction.windowId, transaction.slotId, transaction.mouseButton, transaction.type, ItemStack.EMPTY, transactionID))
+            }
+        }
+    }
+
+    data class InventoryTransaction(val windowId: Int, val slotId: Int, val mouseButton: Int, val type: ClickType, val player: EntityPlayer) {
+        override fun toString(): String {
+            return "windowId: $windowId slotId: $slotId mouseButton: $mouseButton type: ${type.name} player: ${player.name}"
+        }
+    }
+}


### PR DESCRIPTION
Makes baritone work without desyncs

Only does client side inventory transactions on transaction accept. Increase timeout to lower chance of desyncs.