### PR TITLE
add relative positions, fixes #314

### DIFF
--- a/src/main/kotlin/com/lambda/client/command/commands/PacketCommand.kt
+++ b/src/main/kotlin/com/lambda/client/command/commands/PacketCommand.kt
@@ -231,7 +231,7 @@ object PacketCommand : ClientCommand(
                                 val zAbs = z.value.handleRelativePos(player.posZ)
                                 deployPacket(
                                     CPacketPlayer.Position(xAbs, yAbs, zAbs, onGround.value),
-                                    "${xAbs} ${yAbs} ${zAbs} ${onGround.value}"
+                                    "$xAbs $yAbs $zAbs ${onGround.value}"
                                 )
                             }
                         }
@@ -481,12 +481,20 @@ object PacketCommand : ClientCommand(
         connection.sendPacket(packet)
         MessageSendHelper.sendChatMessage("Sent ${TextFormatting.GRAY}${packet.javaClass.name.split(".").lastOrNull()}${TextFormatting.DARK_RED} > ${TextFormatting.GRAY}$info")
     }
-}
 
-private fun String.handleRelativePos(origin: Double): Double {
-    return if (this.startsWith("~")) {
-        this.substring(1).toDouble() + origin
-    } else {
-        this.toDouble()
+    private fun String.handleRelativePos(origin: Double): Double {
+        return if (this.startsWith("~")) {
+            try {
+                this.drop(1).toDouble() + origin
+            } catch (e: NumberFormatException) {
+                origin
+            }
+        } else {
+            try {
+                this.toDouble()
+            } catch (e: NumberFormatException) {
+                origin
+            }
+        }
     }
 }


### PR DESCRIPTION
**Describe the pull**
Add relative positions for packet command. So now people can use ~ to do relative positions.

**Describe how this pull is helpful**
closes #314 

**Additional context**
I believe there should be a better way to do it, so we can do
```kotlin
literal("pos") {
    pos("x") {x ->
        pos("y") {x ->
            pos("z") {x ->
                executeSafe {
                    foo()
                }
            }
        }
    }
}
```
so the player can do `~ ~10 ~` and so we don't have to check if the string is valid relative positions