### PR TITLE
Added MinecartChest/Hopper detection to stashlogger

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/modules/misc/StashLogger.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/misc/StashLogger.kt
@@ -46,12 +46,12 @@ object StashLogger : Module(
     private val hopperDensity by setting("Min Hoppers", 5, 1..20, 1, { logHoppers })
     private val logMinecartChests by setting("MinecartChests", value=true)
     private val MinecartChestDensity by setting("Min MinecartChests", 5, 1..20, 1, { logMinecartChests })
-
     private val logMinecartHoppers by setting("MinecartHoppers", value=true)
     private val MinecartHopperDensity by setting("Min MinecartHoppers", 5, 1..20, 1, { logMinecartHoppers })
 
     private val disableAutoWalk by setting("Disable Auto Walk", false, description = "Disables AutoWalk when a stash is found")
     private val cancelBaritone by setting("Cancel Baritone", false, description = "Cancels Baritone when a stash is found")
+
     private val chunkData = LinkedHashMap<Long, ChunkStats>()
     private val knownPositions = HashSet<BlockPos>()
     private val timer = TickTimer(TimeUnit.SECONDS)

--- a/src/main/kotlin/com/lambda/client/module/modules/misc/StashLogger.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/misc/StashLogger.kt
@@ -17,7 +17,8 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import net.minecraft.client.audio.PositionedSoundRecord
 import net.minecraft.entity.Entity
-import net.minecraft.entity.item.EntityMinecart
+import net.minecraft.entity.item.EntityMinecartChest
+import net.minecraft.entity.item.EntityMinecartHopper
 import net.minecraft.init.SoundEvents
 import net.minecraft.tileentity.*
 import net.minecraft.util.math.BlockPos
@@ -43,8 +44,12 @@ object StashLogger : Module(
     private val dispenserDensity by setting("Min Dispensers", 5, 1..20, 1, { logDispensers })
     private val logHoppers by setting("Hoppers", true)
     private val hopperDensity by setting("Min Hoppers", 5, 1..20, 1, { logHoppers })
-    private val logMinecarts by setting("Minecarts", value=true)
-    private val MinecartDensity by setting("Min Minecarts", 5, 1..20, 1, { logMinecarts })
+    private val logMinecartChests by setting("MinecartChests", value=true)
+    private val MinecartChestDensity by setting("Min MinecartChests", 5, 1..20, 1, { logMinecartChests })
+
+    private val logMinecartHoppers by setting("MinecartHoppers", value=true)
+    private val MinecartHopperDensity by setting("Min MinecartHoppers", 5, 1..20, 1, { logMinecartHoppers })
+
     private val disableAutoWalk by setting("Disable Auto Walk", false, description = "Disables AutoWalk when a stash is found")
     private val cancelBaritone by setting("Cancel Baritone", false, description = "Cancels Baritone when a stash is found")
     private val chunkData = LinkedHashMap<Long, ChunkStats>()
@@ -117,7 +122,8 @@ object StashLogger : Module(
     }
 
     private fun checkEntityType(entity: Entity) =
-        logMinecarts && entity is EntityMinecart
+        logMinecartChests && entity is EntityMinecartChest
+            || logMinecartHoppers && entity is EntityMinecartHopper
 
 
 
@@ -159,7 +165,8 @@ object StashLogger : Module(
         var droppers = 0; private set
         var dispensers = 0; private set
         var hoppers = 0; private set
-        var minecarts = 0; private set
+        var minecartChest = 0; private set
+        var minecartHopper = 0; private set
 
         var hot = false
 
@@ -170,14 +177,16 @@ object StashLogger : Module(
 
         fun add(entity: Entity) {
             when (entity) {
-                is EntityMinecart -> minecarts++
+                is EntityMinecartChest -> minecartChest++
+                is EntityMinecartHopper -> minecartHopper++
                 else -> return
             }
 
 
             entities.add(entity)
 
-            if (minecarts >= MinecartDensity) {
+            if (minecartChest >= MinecartChestDensity
+                || minecartHopper >= MinecartHopperDensity) {
                 hot = true
 
 
@@ -215,8 +224,10 @@ object StashLogger : Module(
             var x = 0.0
             var y = 0.0
             var z = 0.0
-            val size = tileEntities.size.also{entities.size}
+            val size = tileEntities.size.or(entities.size)
             //val size = entities.size
+
+
 
             for (entity in entities){
                 x += entity.position.x
@@ -246,7 +257,9 @@ object StashLogger : Module(
             if (droppers > 0 && logDroppers) statList.add("$droppers dropper${if (droppers == 1) "" else "s"}")
             if (dispensers > 0 && logDispensers) statList.add("$dispensers dispenser${if (dispensers == 1) "" else "s"}")
             if (hoppers > 0 && logHoppers) statList.add("$hoppers hopper${if (hoppers == 1) "" else "s"}")
-            if (minecarts > 0 && logMinecarts) statList.add("$minecarts minecart${if (minecarts == 1) "" else "s"}")
+            if (minecartChest > 0 && logMinecartChests) statList.add("$minecartChest minecartchest${if (minecartChest == 1) "" else "s"}")
+            if (minecartHopper > 0 && logMinecartHoppers) statList.add("$minecartHopper minecartHopper${if (minecartHopper == 1) "" else "s"}")
+
             return statList.joinToString()
         }
     }

--- a/src/main/kotlin/com/lambda/client/module/modules/misc/StashLogger.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/misc/StashLogger.kt
@@ -44,10 +44,10 @@ object StashLogger : Module(
     private val dispenserDensity by setting("Min Dispensers", 5, 1..20, 1, { logDispensers })
     private val logHoppers by setting("Hoppers", true)
     private val hopperDensity by setting("Min Hoppers", 5, 1..20, 1, { logHoppers })
-    private val logMinecartChests by setting("MinecartChests", value=true)
-    private val MinecartChestDensity by setting("Min MinecartChests", 5, 1..20, 1, { logMinecartChests })
-    private val logMinecartHoppers by setting("MinecartHoppers", value=true)
-    private val MinecartHopperDensity by setting("Min MinecartHoppers", 5, 1..20, 1, { logMinecartHoppers })
+    private val logMinecartChests by setting("MinecartChests", true)
+    private val minecartChestDensity by setting("Min MinecartChests", 5, 1..20, 1, { logMinecartChests })
+    private val logMinecartHoppers by setting("MinecartHoppers", true)
+    private val minecartHopperDensity by setting("Min MinecartHoppers", 5, 1..20, 1, { logMinecartHoppers })
 
     private val disableAutoWalk by setting("Disable Auto Walk", false, description = "Disables AutoWalk when a stash is found")
     private val cancelBaritone by setting("Cancel Baritone", false, description = "Cancels Baritone when a stash is found")
@@ -165,8 +165,8 @@ object StashLogger : Module(
         var droppers = 0; private set
         var dispensers = 0; private set
         var hoppers = 0; private set
-        var minecartChest = 0; private set
-        var minecartHopper = 0; private set
+        var minecartChests = 0; private set
+        var minecartHoppers = 0; private set
 
         var hot = false
 
@@ -177,16 +177,16 @@ object StashLogger : Module(
 
         fun add(entity: Entity) {
             when (entity) {
-                is EntityMinecartChest -> minecartChest++
-                is EntityMinecartHopper -> minecartHopper++
+                is EntityMinecartChest -> minecartChests++
+                is EntityMinecartHopper -> minecartHoppers++
                 else -> return
             }
 
 
             entities.add(entity)
 
-            if (minecartChest >= MinecartChestDensity
-                || minecartHopper >= MinecartHopperDensity) {
+            if (minecartChests >= minecartChestDensity
+                || minecartHoppers >= minecartHopperDensity) {
                 hot = true
 
 
@@ -256,8 +256,8 @@ object StashLogger : Module(
             if (droppers > 0 && logDroppers) statList.add("$droppers dropper${if (droppers == 1) "" else "s"}")
             if (dispensers > 0 && logDispensers) statList.add("$dispensers dispenser${if (dispensers == 1) "" else "s"}")
             if (hoppers > 0 && logHoppers) statList.add("$hoppers hopper${if (hoppers == 1) "" else "s"}")
-            if (minecartChest > 0 && logMinecartChests) statList.add("$minecartChest minecartchest${if (minecartChest == 1) "" else "s"}")
-            if (minecartHopper > 0 && logMinecartHoppers) statList.add("$minecartHopper minecartHopper${if (minecartHopper == 1) "" else "s"}")
+            if (minecartChests > 0 && logMinecartChests) statList.add("$minecartChests minecartchest${if (minecartChests == 1) "" else "s"}")
+            if (minecartHoppers > 0 && logMinecartHoppers) statList.add("$minecartHoppers minecartHopper${if (minecartHoppers == 1) "" else "s"}")
 
             return statList.joinToString()
         }

--- a/src/main/kotlin/com/lambda/client/module/modules/misc/StashLogger.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/misc/StashLogger.kt
@@ -55,6 +55,8 @@ object StashLogger : Module(
     private val chunkData = LinkedHashMap<Long, ChunkStats>()
     private val knownPositions = HashSet<BlockPos>()
     private val timer = TickTimer(TimeUnit.SECONDS)
+    //val entities2 = ArrayList<Entity>()
+    val entities3 = ArrayList<Entity>()
 
     init {
         safeListener<TickEvent.ClientTickEvent> {
@@ -63,6 +65,8 @@ object StashLogger : Module(
             defaultScope.launch {
                 coroutineScope {
                     launch {
+
+
                         world.loadedEntityList.toList().forEach(::logEntity)
                         world.loadedTileEntityList.toList().forEach(::logTileEntity)
                         notification()
@@ -104,22 +108,47 @@ object StashLogger : Module(
             if (disableAutoWalk && AutoWalk.isEnabled) AutoWalk.disable()
             if (cancelBaritone && (BaritoneUtils.isPathing || BaritoneUtils.isActive)) BaritoneUtils.cancelEverything()
         }
+
     }
 
 
 
 
     private fun logEntity(entity: Entity){
-        if (!checkEntityType(entity)) return
-        if (!knownPositions.add(entity.position)) return
 
-        val chunk = ChunkPos.asLong(entity.position.x shr 4, entity.position.z shr 4)
+        if (!checkEntityType(entity)) return
+
+        if (!checkEntityID(entity)) return
+
+
+        //knownPositions.add(entity.position
+
+
+        val chunk = ChunkPos.asLong(entity.position.x shr 4 , entity.position.z shr 4)
         val chunkStats = chunkData.getOrPut(chunk, ::ChunkStats)
-        chunkStats.add(entity)
+        chunkStats.add2(entity)
 
 
 
     }
+
+    private fun checkEntityID(entity: Entity): Boolean{
+
+        for((count) in entities3.withIndex()){
+
+           if(entity.uniqueID == entities3[count].uniqueID) {
+               return false
+           }
+
+        }
+
+        entities3.add(entity)
+        return true
+
+
+    }
+
+
 
     private fun checkEntityType(entity: Entity) =
         logMinecartChests && entity is EntityMinecartChest
@@ -170,12 +199,14 @@ object StashLogger : Module(
 
         var hot = false
 
+
+       // private var entities2 = ArrayList<Entity>()
         private val tileEntities = ArrayList<TileEntity>().synchronized()
         private val entities = ArrayList<Entity>().synchronized()
 
 
 
-        fun add(entity: Entity) {
+        fun add2(entity: Entity) {
             when (entity) {
                 is EntityMinecartChest -> minecartChests++
                 is EntityMinecartHopper -> minecartHoppers++
@@ -258,6 +289,7 @@ object StashLogger : Module(
             if (hoppers > 0 && logHoppers) statList.add("$hoppers hopper${if (hoppers == 1) "" else "s"}")
             if (minecartChests > 0 && logMinecartChests) statList.add("$minecartChests minecartchest${if (minecartChests == 1) "" else "s"}")
             if (minecartHoppers > 0 && logMinecartHoppers) statList.add("$minecartHoppers minecartHopper${if (minecartHoppers == 1) "" else "s"}")
+
 
             return statList.joinToString()
         }

--- a/src/main/kotlin/com/lambda/client/module/modules/misc/StashLogger.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/misc/StashLogger.kt
@@ -55,8 +55,7 @@ object StashLogger : Module(
     private val chunkData = LinkedHashMap<Long, ChunkStats>()
     private val knownPositions = HashSet<BlockPos>()
     private val timer = TickTimer(TimeUnit.SECONDS)
-    //val entities2 = ArrayList<Entity>()
-    val entities3 = ArrayList<Entity>()
+    private val entitiesRepeatCheck = ArrayList<Entity>()
 
     init {
         safeListener<TickEvent.ClientTickEvent> {
@@ -134,15 +133,15 @@ object StashLogger : Module(
 
     private fun checkEntityID(entity: Entity): Boolean{
 
-        for((count) in entities3.withIndex()){
+        for((count) in entitiesRepeatCheck.withIndex()){
 
-           if(entity.uniqueID == entities3[count].uniqueID) {
+           if(entity.uniqueID == entitiesRepeatCheck[count].uniqueID) {
                return false
            }
 
         }
 
-        entities3.add(entity)
+        entitiesRepeatCheck.add(entity)
         return true
 
 

--- a/src/main/kotlin/com/lambda/client/module/modules/misc/StashLogger.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/misc/StashLogger.kt
@@ -225,7 +225,6 @@ object StashLogger : Module(
             var y = 0.0
             var z = 0.0
             val size = tileEntities.size.or(entities.size)
-            //val size = entities.size
 
 
 

--- a/src/main/kotlin/com/lambda/client/module/modules/misc/StashLogger.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/misc/StashLogger.kt
@@ -119,10 +119,6 @@ object StashLogger : Module(
 
         if (!checkEntityID(entity)) return
 
-
-        //knownPositions.add(entity.position
-
-
         val chunk = ChunkPos.asLong(entity.position.x shr 4 , entity.position.z shr 4)
         val chunkStats = chunkData.getOrPut(chunk, ::ChunkStats)
         chunkStats.add2(entity)
@@ -138,13 +134,9 @@ object StashLogger : Module(
            if(entity.uniqueID == entitiesRepeatCheck[count].uniqueID) {
                return false
            }
-
         }
-
         entitiesRepeatCheck.add(entity)
         return true
-
-
     }
 
 
@@ -152,9 +144,6 @@ object StashLogger : Module(
     private fun checkEntityType(entity: Entity) =
         logMinecartChests && entity is EntityMinecartChest
             || logMinecartHoppers && entity is EntityMinecartHopper
-
-
-
 
 
 

--- a/src/main/kotlin/com/lambda/client/module/modules/misc/StashLogger.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/misc/StashLogger.kt
@@ -16,6 +16,9 @@ import com.lambda.client.commons.extension.synchronized
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import net.minecraft.client.audio.PositionedSoundRecord
+import net.minecraft.entity.Entity
+import net.minecraft.entity.item.EntityMinecartChest
+import net.minecraft.entity.item.EntityMinecartHopper
 import net.minecraft.init.SoundEvents
 import net.minecraft.tileentity.*
 import net.minecraft.util.math.BlockPos
@@ -41,9 +44,14 @@ object StashLogger : Module(
     private val dispenserDensity by setting("Min Dispensers", 5, 1..20, 1, { logDispensers })
     private val logHoppers by setting("Hoppers", true)
     private val hopperDensity by setting("Min Hoppers", 5, 1..20, 1, { logHoppers })
+    private val logMinecartChests by setting("MinecartChests", value=true)
+    private val MinecartChestDensity by setting("Min MinecartChests", 5, 1..20, 1, { logMinecartChests })
+
+    private val logMinecartHoppers by setting("MinecartHoppers", value=true)
+    private val MinecartHopperDensity by setting("Min MinecartHoppers", 5, 1..20, 1, { logMinecartHoppers })
+
     private val disableAutoWalk by setting("Disable Auto Walk", false, description = "Disables AutoWalk when a stash is found")
     private val cancelBaritone by setting("Cancel Baritone", false, description = "Cancels Baritone when a stash is found")
-
     private val chunkData = LinkedHashMap<Long, ChunkStats>()
     private val knownPositions = HashSet<BlockPos>()
     private val timer = TickTimer(TimeUnit.SECONDS)
@@ -55,6 +63,7 @@ object StashLogger : Module(
             defaultScope.launch {
                 coroutineScope {
                     launch {
+                        world.loadedEntityList.toList().forEach(::logEntity)
                         world.loadedTileEntityList.toList().forEach(::logTileEntity)
                         notification()
                     }
@@ -97,6 +106,32 @@ object StashLogger : Module(
         }
     }
 
+
+
+
+    private fun logEntity(entity: Entity){
+        if (!checkEntityType(entity)) return
+        if (!knownPositions.add(entity.position)) return
+
+        val chunk = ChunkPos.asLong(entity.position.x shr 4, entity.position.z shr 4)
+        val chunkStats = chunkData.getOrPut(chunk, ::ChunkStats)
+        chunkStats.add(entity)
+
+
+
+    }
+
+    private fun checkEntityType(entity: Entity) =
+        logMinecartChests && entity is EntityMinecartChest
+            || logMinecartHoppers && entity is EntityMinecartHopper
+
+
+
+
+
+
+
+
     private fun logTileEntity(tileEntity: TileEntity) {
         if (!checkTileEntityType(tileEntity)) return
         if (!knownPositions.add(tileEntity.pos)) return
@@ -107,6 +142,8 @@ object StashLogger : Module(
         chunkStats.add(tileEntity)
     }
 
+
+
     private fun checkTileEntityType(tileEntity: TileEntity) =
         logChests && tileEntity is TileEntityChest
             || logShulkers && tileEntity is TileEntityShulkerBox
@@ -114,16 +151,49 @@ object StashLogger : Module(
             || logDispensers && tileEntity is TileEntityDispenser
             || logHoppers && tileEntity is TileEntityHopper
 
+
+
+
+
+
+
+
+
     private class ChunkStats {
         var chests = 0; private set
         var shulkers = 0; private set
         var droppers = 0; private set
         var dispensers = 0; private set
         var hoppers = 0; private set
+        var minecartChest = 0; private set
+        var minecartHopper = 0; private set
 
         var hot = false
 
         private val tileEntities = ArrayList<TileEntity>().synchronized()
+        private val entities = ArrayList<Entity>().synchronized()
+
+
+
+        fun add(entity: Entity) {
+            when (entity) {
+                is EntityMinecartChest -> minecartChest++
+                is EntityMinecartHopper -> minecartHopper++
+                else -> return
+            }
+
+
+            entities.add(entity)
+
+            if (minecartChest >= MinecartChestDensity
+                || minecartHopper >= MinecartHopperDensity) {
+                hot = true
+
+
+            }
+        }
+
+
 
         fun add(tileEntity: TileEntity) {
             when (tileEntity) {
@@ -132,6 +202,7 @@ object StashLogger : Module(
                 is TileEntityDropper -> droppers++
                 is TileEntityDispenser -> dispensers++
                 is TileEntityHopper -> hoppers++
+
                 else -> return
             }
 
@@ -146,17 +217,31 @@ object StashLogger : Module(
             }
         }
 
+
+
+
         fun center(): BlockPos {
             var x = 0.0
             var y = 0.0
             var z = 0.0
-            val size = tileEntities.size
+            val size = tileEntities.size.or(entities.size)
+            //val size = entities.size
+
+
+
+            for (entity in entities){
+                x += entity.position.x
+                y += entity.position.y
+                z += entity.position.z
+
+            }
 
             for (tileEntity in tileEntities) {
                 x += tileEntity.pos.x
                 y += tileEntity.pos.y
                 z += tileEntity.pos.z
             }
+
 
             x /= size
             y /= size
@@ -172,6 +257,9 @@ object StashLogger : Module(
             if (droppers > 0 && logDroppers) statList.add("$droppers dropper${if (droppers == 1) "" else "s"}")
             if (dispensers > 0 && logDispensers) statList.add("$dispensers dispenser${if (dispensers == 1) "" else "s"}")
             if (hoppers > 0 && logHoppers) statList.add("$hoppers hopper${if (hoppers == 1) "" else "s"}")
+            if (minecartChest > 0 && logMinecartChests) statList.add("$minecartChest minecartchest${if (minecartChest == 1) "" else "s"}")
+            if (minecartHopper > 0 && logMinecartHoppers) statList.add("$minecartHopper minecartHopper${if (minecartHopper == 1) "" else "s"}")
+
             return statList.joinToString()
         }
     }


### PR DESCRIPTION
**Describe the pull**
It adds MinecartChests and MinecartHoppers to the Stashlogger because some people hide their stashes in tons of minecart chests merged.

**Describe how this pull is helpful**
It helps people find stashes.

**Additional context**
Edit: Nothing Anymore. I changed the way it detects doubles so it finally detects merged minecarts correctly and stopped detecting the minecarts as a new entity when they move.