### PR TITLE
Add show food on rideable mobs

### DIFF
--- a/src/main/java/com/lambda/mixin/gui/MixinGuiIngameForge.java
+++ b/src/main/java/com/lambda/mixin/gui/MixinGuiIngameForge.java
@@ -1,14 +1,22 @@
 package com.lambda.mixin.gui;
 
 import com.lambda.client.module.modules.player.Freecam;
+import com.lambda.client.module.modules.render.HungerOverlay;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.client.GuiIngameForge;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = GuiIngameForge.class, remap = false)
-public class MixinGuiIngameForge {
+public abstract class MixinGuiIngameForge {
+
+    @Shadow
+    public abstract void renderFood(int width, int height);
+
     @ModifyVariable(method = "renderAir", at = @At(value = "STORE", ordinal = 0))
     private EntityPlayer renderAir$getRenderViewEntity(EntityPlayer renderViewEntity) {
         return Freecam.getRenderViewEntity(renderViewEntity);
@@ -27,5 +35,12 @@ public class MixinGuiIngameForge {
     @ModifyVariable(method = "renderHealthMount", at = @At(value = "STORE", ordinal = 0))
     private EntityPlayer renderHealthMount$getRenderViewEntity(EntityPlayer renderViewEntity) {
         return Freecam.getRenderViewEntity(renderViewEntity);
+    }
+
+    @Inject(method = "renderHealthMount", at = @At("HEAD"))
+    private void renderHealthMount(int width, int height, CallbackInfo ci) {
+        if (HungerOverlay.INSTANCE.getRenderFoodOnRideable()) {
+            this.renderFood(width, height);
+        }
     }
 }

--- a/src/main/kotlin/com/lambda/client/module/modules/render/HungerOverlay.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/render/HungerOverlay.kt
@@ -27,6 +27,7 @@ object HungerOverlay : Module(
     private val saturationOverlay by setting("Saturation Overlay", true)
     private val foodHungerOverlay by setting("Food Hunger Overlay", true)
     private val foodSaturationOverlay by setting("Food Saturation Overlay", true)
+    val renderFoodOnRideable by setting("Render Food On Rideables", true)
 
     private val icons = ResourceLocation("lambda/textures/hungeroverlay.png")
 


### PR DESCRIPTION
**Describe the pull**
This Pull add a new option to HungerOverlay, showing the players hunger while mounted on Horses, Pigs, and other rideable entities.

**Describe how this pull is helpful**
Requested by @Edouard127 in the Lambda discord server.

**Additional context**
![16318](https://user-images.githubusercontent.com/53945697/173260251-ec1793c4-a246-48ed-a1c4-dd3e6f1b19e5.png)

