### PR TITLE
Forward all PlayerInteractEvents to bus

### DIFF
--- a/src/main/kotlin/com/lambda/client/event/ForgeEventProcessor.kt
+++ b/src/main/kotlin/com/lambda/client/event/ForgeEventProcessor.kt
@@ -126,7 +126,7 @@ internal object ForgeEventProcessor {
     }
 
     @SubscribeEvent
-    fun onLeftClickBlock(event: PlayerInteractEvent.LeftClickBlock) {
+    fun onPlayerInteractEvent(event: PlayerInteractEvent) {
         LambdaEventBus.post(event)
     }
 


### PR DESCRIPTION
Forward all sub-classes of PlayerInteractEvent to the event-bus, not just LeftClickBlock.
This includes EntityInteract, EntityInteractSpecific, LeftClickBlock, LeftClickEmpty, RightClickBlock, RightClickEmpty, RightClickItem
There are no overlaps with existing event listeners.