### PR TITLE
removed fading animation from tracers

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/modules/render/Tracers.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/render/Tracers.kt
@@ -93,16 +93,7 @@ object Tracers : Module(
 
             val cacheMap = HashMap<Entity, Pair<ColorHolder, Float>>()
             for (entity in entityList) {
-                cacheMap[entity] = Pair(getColor(entity), 0f)
-            }
-
-            for ((entity, pair) in renderList) {
-                cacheMap.computeIfPresent(entity) { _, cachePair -> Pair(cachePair.first, min(pair.second + 0.075f, 1f)) }
-                cacheMap.computeIfAbsent(entity) { Pair(getColor(entity), pair.second - 0.05f) }
-
-                if (pair.second < 0f) {
-                    cacheMap.remove(entity)
-                }
+                cacheMap[entity] = Pair(getColor(entity), 1f)
             }
 
             renderList.clear()


### PR DESCRIPTION
**Describe the pull**
This PR removes the fading animation of tracers.

**Describe how this pull is helpful**
For some reason the Tracers module is written in a way that tracers are not shown or hidden immediately but they fade in and out over the course of maybe 500ms.
In my opinion this defeats the purpose of tracers, since they are meant to display information in a quick and flashy way and they should not try to be subtle and smooth.
It also gives you a significant tactical disadvantage because it will make you notice other players or entities 500ms later than they will notice you. If an entity just quickly pops in and out of your render-range you won't even know it was there, whereas you would have been able to see it with every other utility client.
Furthermore, the fading is not consistent within Lambda, as it only occurs for entities highlighted by the Tracers module. Every other tracer drawn by Lambda (for example in the search module) does not fade, which makes this feature even more confusing.
Please tell me if you think this PR is unjustified.