### PR TITLE
Unofficial plugins repo listing

### DIFF
--- a/src/main/kotlin/com/lambda/client/LambdaMod.kt
+++ b/src/main/kotlin/com/lambda/client/LambdaMod.kt
@@ -37,6 +37,7 @@ class LambdaMod {
         const val GITHUB_API = "https://api.github.com/"
         private const val MAIN_ORG = "lambda-client"
         const val PLUGIN_ORG = "lambda-plugins"
+        const val UNOFFICIAL_PLUGIN_API = "https://lambda-plugin-api.herokuapp.com/plugins"
         private const val REPO_NAME = "lambda"
         const val CAPES_JSON = "https://raw.githubusercontent.com/${MAIN_ORG}/cape-api/capes/capes.json"
         const val RELEASES_API = "${GITHUB_API}repos/${MAIN_ORG}/${REPO_NAME}/releases"

--- a/src/main/kotlin/com/lambda/client/LambdaMod.kt
+++ b/src/main/kotlin/com/lambda/client/LambdaMod.kt
@@ -37,7 +37,7 @@ class LambdaMod {
         const val GITHUB_API = "https://api.github.com/"
         private const val MAIN_ORG = "lambda-client"
         const val PLUGIN_ORG = "lambda-plugins"
-        const val UNOFFICIAL_PLUGIN_API = "https://lambda-plugin-api.herokuapp.com/plugins"
+        const val UNOFFICIAL_PLUGIN_API = "https://lambda-plugin-api.herokuapp.com/"
         private const val REPO_NAME = "lambda"
         const val CAPES_JSON = "https://raw.githubusercontent.com/${MAIN_ORG}/cape-api/capes/capes.json"
         const val RELEASES_API = "${GITHUB_API}repos/${MAIN_ORG}/${REPO_NAME}/releases"

--- a/src/main/kotlin/com/lambda/client/gui/clickgui/LambdaClickGui.kt
+++ b/src/main/kotlin/com/lambda/client/gui/clickgui/LambdaClickGui.kt
@@ -153,10 +153,9 @@ object LambdaClickGui : AbstractLambdaGui<ModuleSettingWindow, AbstractModule>()
                 LambdaMod.LOG.info("Requesting all public plugin repos from: $repoUrl")
                 val pluginRepos = JsonParser().parse(rawJson).asJsonArray
 
-                val unofficialPluginJson = ConnectionUtils.requestRawJsonFrom(LambdaMod.UNOFFICIAL_PLUGIN_API)
+                val unofficialPluginJson = ConnectionUtils.requestRawJsonFrom(LambdaMod.UNOFFICIAL_PLUGIN_API + "/plugins")
                 val unofficialPluginData = JsonParser().parse(unofficialPluginJson).asJsonArray
                 LambdaMod.LOG.info("Requesting all unofficial plugins from: ${LambdaMod.UNOFFICIAL_PLUGIN_API}")
-                LambdaMod.LOG.info("Debug: ${unofficialPluginData.toString()}")
 
 
                 pluginRepos.forEach { pluginRepo ->
@@ -191,7 +190,7 @@ object LambdaClickGui : AbstractLambdaGui<ModuleSettingWindow, AbstractModule>()
 
                 unofficialPluginData.forEach { plugin ->
                     val pluginObject = plugin.asJsonObject
-                    val downloadURL = "https://lambda-plugin-api.herokuapp.com/plugins/download/${pluginObject.get("plugin").asString}";
+                    val downloadURL = LambdaMod.UNOFFICIAL_PLUGIN_API + "/download/" + pluginObject.get("plugin").asString
                     LambdaMod.LOG.info("Requesting details about: $downloadURL")
                     val downloadLink = ConnectionUtils.requestRawJsonFrom(downloadURL) { e ->
                         LambdaMod.LOG.error("Failed to get plugin download link", e)


### PR DESCRIPTION
**Describe the pull**
Only adds functionality to scan unofficial plugins from the api.

**Describe how this pull is helpful**
There are not a lot of official plugins, and finding and downloading unofficial plugins can be a lot of work. I made a [repo](https://github.com/lambda-client-unofficial/plugin-repo) that is collecting all the unofficial plugins, and made an API for it(hosted on heroku sadly). This pr is the client integration, and it will probably be integrated into the discord bot later.

**Additional context**
There should be a warning dialog that warns the user the plugin is unofficial and suggests the user to review its source code before downloading.
