### PR TITLE
Fixed a spelling mistake under the description of Breadcrums

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/modules/render/Breadcrumbs.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/render/Breadcrumbs.kt
@@ -26,7 +26,7 @@ import kotlin.math.sin
 
 object Breadcrumbs : Module(
     name = "Breadcrumbs",
-    description = "Draws a tail behind as you move",
+    description = "Draws a trail behind as you move",
     category = Category.RENDER,
     alwaysListening = true
 ) {
@@ -69,7 +69,7 @@ object Breadcrumbs : Module(
             }
             if (!shouldRecord(true)) return@safeListener
 
-            /* Adding server and dimension to the map if they are not exist */
+            /* Adding server and dimension to the map if they don't exist */
             val serverIP = getServerIP()
             val dimension = player.dimension
 


### PR DESCRIPTION
Fixed a singular spelling mistake that annoyed me a little

**Describe the pull**
Singular spelling mistake fix under the description when you hover over the module, changing the word "Tail" to "trail" as breadcrums leaves a trail behind you, not a tail.

**Describe how this pull is helpful**
It looks better tbh.

**Additional context**
None more to be had I just got annoyed seeing it once and wanted to fix it.
