### PR TITLE
Username & InventoryViewer Improvement

### DIFF
--- a/src/main/kotlin/com/lambda/client/gui/hudgui/elements/client/Username.kt
+++ b/src/main/kotlin/com/lambda/client/gui/hudgui/elements/client/Username.kt
@@ -13,9 +13,9 @@ internal object Username : LabelHud(
     private val suffix = setting("Suffix", "")
 
     override fun SafeClientEvent.updateText() {
-        displayText.add(prefix.value, primaryColor)
+        if (prefix.value != "") displayText.add(prefix.value, primaryColor)
         displayText.add(mc.session.username, secondaryColor)
-        displayText.add(suffix.value, primaryColor)
+        if (suffix.value != "") displayText.add(suffix.value, primaryColor)
     }
 
 }

--- a/src/main/kotlin/com/lambda/client/gui/hudgui/elements/player/InventoryViewer.kt
+++ b/src/main/kotlin/com/lambda/client/gui/hudgui/elements/player/InventoryViewer.kt
@@ -110,6 +110,7 @@ internal object InventoryViewer : HudElement(
         safeListener<PacketEvent.Receive> {
             if (it.packet !is SPacketOpenWindow) return@safeListener
             if (it.packet.guiId != "minecraft:container") return@safeListener
+            if (it.packet.windowTitle !is TextComponentTranslation) return@safeListener
             if ((it.packet.windowTitle as TextComponentTranslation).key != "container.enderchest") return@safeListener
 
             openedEnderChest = it.packet.windowId

--- a/src/main/kotlin/com/lambda/client/gui/hudgui/elements/player/InventoryViewer.kt
+++ b/src/main/kotlin/com/lambda/client/gui/hudgui/elements/player/InventoryViewer.kt
@@ -46,7 +46,8 @@ internal object InventoryViewer : HudElement(
     override val hudWidth: Float = 162.0f
     override val hudHeight: Float = 54.0f
 
-    private var openedEnderChest : Int = -1
+    private var openedEnderChest: Int = -1
+
     override fun renderHud(vertexHelper: VertexHelper) {
         super.renderHud(vertexHelper)
         runSafe {
@@ -105,39 +106,32 @@ internal object InventoryViewer : HudElement(
         safeListener<ConnectionEvent.Disconnect> {
             openedEnderChest = -1
         }
+
         safeListener<PacketEvent.Receive> {
             if (it.packet !is SPacketOpenWindow) return@safeListener
             if (it.packet.guiId != "minecraft:container") return@safeListener
-            try {
-                if ((it.packet.windowTitle as TextComponentTranslation).key != "container.enderchest") return@safeListener
-                openedEnderChest = it.packet.windowId
-            } catch (_: Exception) {
-            }
+            if ((it.packet.windowTitle as TextComponentTranslation).key != "container.enderchest") return@safeListener
+
+            openedEnderChest = it.packet.windowId
         }
 
         safeListener<PacketEvent.PostSend> {
             if (it.packet !is CPacketCloseWindow) return@safeListener
-            if (it.packet.windowID == openedEnderChest) {
-                if (mc.currentScreen is GuiContainer) {
-                    val container = (mc.currentScreen as GuiContainer).inventorySlots
-                    if (container is ContainerChest && container.lowerChestInventory is InventoryBasic) {
-                        if (container.windowId == openedEnderChest) {
-                            for (i in 0..26) enderChestContents[i] = container.inventory[i]
-                        }
-                    }
-                }
-                openedEnderChest = -1
-            }
+            if (it.packet.windowID != openedEnderChest) return@safeListener
+
+            checkEnderChest()
+            openedEnderChest = -1
         }
     }
 
     private fun checkEnderChest() {
-        if (mc.currentScreen is GuiContainer) {
-            val container = (mc.currentScreen as GuiContainer).inventorySlots
-            if (container is ContainerChest && container.lowerChestInventory is InventoryBasic) {
-                if (container.windowId == openedEnderChest) {
-                    for (i in 0..26) enderChestContents[i] = container.inventory[i]
-                }
+        if (mc.currentScreen !is GuiContainer) return
+
+        val container = (mc.currentScreen as GuiContainer).inventorySlots
+
+        if (container is ContainerChest && container.lowerChestInventory is InventoryBasic) {
+            if (container.windowId == openedEnderChest) {
+                for (i in 0..26) enderChestContents[i] = container.inventory[i]
             }
         }
     }

--- a/src/main/kotlin/com/lambda/client/gui/hudgui/elements/player/InventoryViewer.kt
+++ b/src/main/kotlin/com/lambda/client/gui/hudgui/elements/player/InventoryViewer.kt
@@ -110,8 +110,9 @@ internal object InventoryViewer : HudElement(
         safeListener<PacketEvent.Receive> {
             if (it.packet !is SPacketOpenWindow) return@safeListener
             if (it.packet.guiId != "minecraft:container") return@safeListener
-            if (it.packet.windowTitle !is TextComponentTranslation) return@safeListener
-            if ((it.packet.windowTitle as TextComponentTranslation).key != "container.enderchest") return@safeListener
+            val title = it.packet.windowTitle
+            if (title !is TextComponentTranslation) return@safeListener
+            if (title.key != "container.enderchest") return@safeListener
 
             openedEnderChest = it.packet.windowId
         }
@@ -126,9 +127,11 @@ internal object InventoryViewer : HudElement(
     }
 
     private fun checkEnderChest() {
-        if (mc.currentScreen !is GuiContainer) return
+        val guiScreen = mc.currentScreen
 
-        val container = (mc.currentScreen as GuiContainer).inventorySlots
+        if (guiScreen !is GuiContainer) return
+
+        val container = guiScreen.inventorySlots
 
         if (container is ContainerChest && container.lowerChestInventory is InventoryBasic) {
             if (container.windowId == openedEnderChest) {


### PR DESCRIPTION
**Describe the pull**
### Username fix
>(Fixes 1-space blank when prefix or suffix is defined with blank)

### Improved InventoryViewer, especially enderchest part.

> Fixed EnderChest Desync Problem(Desyncs when player close ender chest and moves item at same time) with using CPacketCloseWindow Listener.

> Now catches Ender chest in any language(original method didn't work when player had different langauge setting) with using TextComponentTranslation.key instead of name(This method needed to use SPacketOpenWindow).

**Describe how this pull is helpful**
better Performance

**Additional context**
well It's the first time that i'm opening the pull request, idk am i doing right but anyways
and I couldn't find the part that could cause bug but didn't test on high-ping(i don't know the high-ping environment has a potential power that could cause error, but anyways)