### PR TITLE
Quick Fix for a bug in AutoObsidian

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/modules/misc/AutoObsidian.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/misc/AutoObsidian.kt
@@ -73,6 +73,7 @@ object AutoObsidian : Module(
     private val delayTicks by setting("Delay", 4, 1..10, 1, unit = " ticks")
     private val rotationMode by setting("Rotation Mode", RotationMode.SPOOF)
     private val maxReach by setting("Max Reach", 4.9f, 2.0f..6.0f, 0.1f)
+    private val disableOnDisconnect by setting("Disable on Disconnect", true)
 
     private enum class FillMode(override val displayName: String, val message: String) : DisplayEnum {
         TARGET_STACKS("Target Stacks", "Target stacks reached"),
@@ -265,7 +266,7 @@ object AutoObsidian : Module(
         } else {
             MessageSendHelper.sendChatMessage("$chatName No valid position for placing shulker box / ender chest nearby, disabling.")
             mc.soundHandler.playSound(PositionedSoundRecord.getRecord(SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.0f))
-            disable()
+            if(disableOnDisconnect) disable()
         }
     }
 

--- a/src/main/kotlin/com/lambda/client/module/modules/misc/AutoObsidian.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/misc/AutoObsidian.kt
@@ -73,7 +73,6 @@ object AutoObsidian : Module(
     private val delayTicks by setting("Delay", 4, 1..10, 1, unit = " ticks")
     private val rotationMode by setting("Rotation Mode", RotationMode.SPOOF)
     private val maxReach by setting("Max Reach", 4.9f, 2.0f..6.0f, 0.1f)
-    private val disableOnDisconnect by setting("Disable on Disconnect", true)
 
     private enum class FillMode(override val displayName: String, val message: String) : DisplayEnum {
         TARGET_STACKS("Target Stacks", "Target stacks reached"),
@@ -151,7 +150,7 @@ object AutoObsidian : Module(
 
         safeListener<TickEvent.ClientTickEvent>(69) {
             if (it.phase != TickEvent.Phase.START || PauseProcess.isActive ||
-                (world.difficulty == EnumDifficulty.PEACEFUL &&
+                (world.difficulty == EnumDifficulty.EASY &&
                     player.dimension == 1 &&
                     @Suppress("UNNECESSARY_SAFE_CALL")
                     player.serverBrand?.contains("2b2t") == true)) return@safeListener
@@ -266,7 +265,7 @@ object AutoObsidian : Module(
         } else {
             MessageSendHelper.sendChatMessage("$chatName No valid position for placing shulker box / ender chest nearby, disabling.")
             mc.soundHandler.playSound(PositionedSoundRecord.getRecord(SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.0f))
-            if(disableOnDisconnect) disable()
+            disable()
         }
     }
 


### PR DESCRIPTION
**Describe the pull**
Quick Fix for a bug in AutoObsidian which made it disable on disconnect

**Additional context**
It gets disabled since it can't find a valid position on a world load.
