### PR TITLE
Add a timer "only when inputting" option

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/modules/player/Timer.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/player/Timer.kt
@@ -14,7 +14,7 @@ object Timer : Module(
     category = Category.PLAYER,
     modulePriority = 500
 ) {
-    private val onlyWhenInputting by setting("Only when inputting", false)
+    private val onlyWhenInputting by setting("Only When Inputting", false)
     private val slow by setting("Slow Mode", false)
     private val tickNormal by setting("Tick N", 2.0f, 1f..10f, 0.1f, { !slow })
     private val tickSlow by setting("Tick S", 8f, 1f..10f, 0.1f, { slow })

--- a/src/main/kotlin/com/lambda/client/module/modules/player/Timer.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/player/Timer.kt
@@ -5,6 +5,7 @@ import com.lambda.client.manager.managers.TimerManager.modifyTimer
 import com.lambda.client.manager.managers.TimerManager.resetTimer
 import com.lambda.client.module.Category
 import com.lambda.client.module.Module
+import com.lambda.client.util.MovementUtils
 import net.minecraftforge.fml.common.gameevent.TickEvent
 
 object Timer : Module(
@@ -13,6 +14,7 @@ object Timer : Module(
     category = Category.PLAYER,
     modulePriority = 500
 ) {
+    private val onlyWhenInputting by setting("Only when inputting", false)
     private val slow by setting("Slow Mode", false)
     private val tickNormal by setting("Tick N", 2.0f, 1f..10f, 0.1f, { !slow })
     private val tickSlow by setting("Tick S", 8f, 1f..10f, 0.1f, { slow })
@@ -26,7 +28,9 @@ object Timer : Module(
             if (it.phase != TickEvent.Phase.END) return@listener
 
             val multiplier = if (!slow) tickNormal else tickSlow / 10.0f
-            modifyTimer(50.0f / multiplier)
+            if (onlyWhenInputting) {
+                if (MovementUtils.isInputting) modifyTimer(50.0f / multiplier)
+            } else modifyTimer(50.0f / multiplier)
         }
     }
 }

--- a/src/main/kotlin/com/lambda/client/module/modules/player/Timer.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/player/Timer.kt
@@ -5,6 +5,7 @@ import com.lambda.client.manager.managers.TimerManager.modifyTimer
 import com.lambda.client.manager.managers.TimerManager.resetTimer
 import com.lambda.client.module.Category
 import com.lambda.client.module.Module
+import com.lambda.client.module.modules.client.ClickGUI
 import com.lambda.client.util.MovementUtils
 import net.minecraftforge.fml.common.gameevent.TickEvent
 
@@ -26,6 +27,11 @@ object Timer : Module(
 
         listener<TickEvent.ClientTickEvent> {
             if (it.phase != TickEvent.Phase.END) return@listener
+
+            if (ClickGUI.isEnabled) {
+                resetTimer()
+                return@listener
+            }
 
             val multiplier = if (!slow) tickNormal else tickSlow / 10.0f
             if (onlyWhenInputting) {


### PR DESCRIPTION
**Describe the pull**
I added a timer option that when enabled, timer only works when the player is inputting.

**Describe how this pull is helpful**
This is helpful for flagging less.

**Additional context**
I am a bit rusty, so the if statement can probably be simplified.
