### PR TITLE
Mouse bindings

### DIFF
--- a/src/main/kotlin/com/lambda/client/event/ForgeEventProcessor.kt
+++ b/src/main/kotlin/com/lambda/client/event/ForgeEventProcessor.kt
@@ -87,7 +87,7 @@ internal object ForgeEventProcessor {
     fun onEventMouse(event: InputEvent.MouseInputEvent) {
         LambdaEventBus.post(event)
         if (!Mouse.getEventButtonState()) return
-        ModuleManager.onMouseBind(Mouse.getEventButton())
+        ModuleManager.onMouseBind(Mouse.getEventButton() + 1)
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)

--- a/src/main/kotlin/com/lambda/client/event/ForgeEventProcessor.kt
+++ b/src/main/kotlin/com/lambda/client/event/ForgeEventProcessor.kt
@@ -22,6 +22,7 @@ import net.minecraftforge.fml.common.gameevent.InputEvent
 import net.minecraftforge.fml.common.gameevent.TickEvent
 import net.minecraftforge.fml.common.network.FMLNetworkEvent
 import org.lwjgl.input.Keyboard
+import org.lwjgl.input.Mouse
 
 internal object ForgeEventProcessor {
     private val mc = Wrapper.minecraft
@@ -82,6 +83,13 @@ internal object ForgeEventProcessor {
         ModuleManager.onBind(Keyboard.getEventKey())
     }
 
+    @SubscribeEvent
+    fun onEventMouse(event: InputEvent.MouseInputEvent) {
+        LambdaEventBus.post(event)
+        if (!Mouse.getEventButtonState()) return
+        ModuleManager.onMouseBind(Mouse.getEventButton())
+    }
+
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     fun onChatSent(event: ClientChatEvent) {
         MessageDetection.Command.BARITONE.removedOrNull(event.message)?.let {
@@ -92,11 +100,6 @@ internal object ForgeEventProcessor {
             CommandManager.runCommand(event.message.removePrefix(CommandManager.prefix))
             event.isCanceled = true
         }
-    }
-
-    @SubscribeEvent
-    fun onEventMouse(event: InputEvent.MouseInputEvent) {
-        LambdaEventBus.post(event)
     }
 
     /**

--- a/src/main/kotlin/com/lambda/client/gui/rgui/component/BindButton.kt
+++ b/src/main/kotlin/com/lambda/client/gui/rgui/component/BindButton.kt
@@ -20,6 +20,11 @@ class BindButton(
 
     override fun onRelease(mousePos: Vec2f, buttonId: Int) {
         super.onRelease(mousePos, buttonId)
+        if (listening && buttonId > 2) {
+            setting.value.apply {
+                setMouseBind(buttonId)
+            }
+        }
         listening = !listening
     }
 

--- a/src/main/kotlin/com/lambda/client/gui/rgui/component/BindButton.kt
+++ b/src/main/kotlin/com/lambda/client/gui/rgui/component/BindButton.kt
@@ -4,6 +4,7 @@ import com.lambda.client.module.modules.client.ClickGUI
 import com.lambda.client.module.modules.client.CustomFont
 import com.lambda.client.module.modules.client.GuiColors
 import com.lambda.client.setting.settings.impl.other.BindSetting
+import com.lambda.client.util.Bind.Companion.minMouseButton
 import com.lambda.client.util.graphics.VertexHelper
 import com.lambda.client.util.graphics.font.FontRenderAdapter
 import com.lambda.client.util.math.Vec2f
@@ -20,9 +21,9 @@ class BindButton(
 
     override fun onRelease(mousePos: Vec2f, buttonId: Int) {
         super.onRelease(mousePos, buttonId)
-        if (listening && buttonId > 2) {
+        if (listening && buttonId >= minMouseButton) {
             setting.value.apply {
-                setMouseBind(buttonId)
+                setMouseBind(buttonId + 1)
             }
         }
         listening = !listening

--- a/src/main/kotlin/com/lambda/client/gui/rgui/component/BindButton.kt
+++ b/src/main/kotlin/com/lambda/client/gui/rgui/component/BindButton.kt
@@ -4,7 +4,7 @@ import com.lambda.client.module.modules.client.ClickGUI
 import com.lambda.client.module.modules.client.CustomFont
 import com.lambda.client.module.modules.client.GuiColors
 import com.lambda.client.setting.settings.impl.other.BindSetting
-import com.lambda.client.util.Bind.Companion.minMouseButton
+import com.lambda.client.util.Bind.Companion.minMouseIndex
 import com.lambda.client.util.graphics.VertexHelper
 import com.lambda.client.util.graphics.font.FontRenderAdapter
 import com.lambda.client.util.math.Vec2f
@@ -21,7 +21,7 @@ class BindButton(
 
     override fun onRelease(mousePos: Vec2f, buttonId: Int) {
         super.onRelease(mousePos, buttonId)
-        if (listening && buttonId >= minMouseButton) {
+        if (listening && buttonId >= minMouseIndex) {
             setting.value.apply {
                 setMouseBind(buttonId + 1)
             }

--- a/src/main/kotlin/com/lambda/client/module/ModuleManager.kt
+++ b/src/main/kotlin/com/lambda/client/module/ModuleManager.kt
@@ -69,5 +69,11 @@ object ModuleManager : AsyncLoader<List<Class<out AbstractModule>>> {
         }
     }
 
+    internal fun onMouseBind(eventMouse: Int) {
+        for (module in modules) {
+            if (module.bind.value.isMouseDown(eventMouse)) module.toggle()
+        }
+    }
+
     fun getModuleOrNull(moduleName: String?) = moduleName?.let { moduleSet[it] }
 }

--- a/src/main/kotlin/com/lambda/client/module/ModuleManager.kt
+++ b/src/main/kotlin/com/lambda/client/module/ModuleManager.kt
@@ -64,15 +64,15 @@ object ModuleManager : AsyncLoader<List<Class<out AbstractModule>>> {
 
     internal fun onBind(eventKey: Int) {
         if (Keyboard.isKeyDown(Keyboard.KEY_F3)) return  // if key is the 'none' key (stuff like mod key in i3 might return 0)
-        for (module in modules) {
-            if (module.bind.value.isDown(eventKey)) module.toggle()
-        }
+        modules.filter {
+            it.bind.value.isDown(eventKey)
+        }.forEach { it.toggle() }
     }
 
     internal fun onMouseBind(eventMouse: Int) {
-        for (module in modules) {
-            if (module.bind.value.isMouseDown(eventMouse)) module.toggle()
-        }
+        modules.filter {
+            it.bind.value.isMouseDown(eventMouse)
+        }.forEach { it.toggle() }
     }
 
     fun getModuleOrNull(moduleName: String?) = moduleName?.let { moduleSet[it] }

--- a/src/main/kotlin/com/lambda/client/setting/settings/impl/other/BindSetting.kt
+++ b/src/main/kotlin/com/lambda/client/setting/settings/impl/other/BindSetting.kt
@@ -14,7 +14,7 @@ class BindSetting(
     description: String = ""
 ) : ImmutableSetting<Bind>(name, value, visibility, { _, input -> input }, description, unit = "") {
 
-    override val defaultValue: Bind = Bind(TreeSet(value.modifierKeys), value.key)
+    override val defaultValue: Bind = Bind(TreeSet(value.modifierKeys), value.key, null)
 
     override fun resetValue() {
         value.setBind(defaultValue.modifierKeys, defaultValue.key)
@@ -23,6 +23,10 @@ class BindSetting(
     override fun setValue(valueIn: String) {
         if (valueIn.equals("None", ignoreCase = true)) {
             value.clear()
+            return
+        }
+        if (valueIn.startsWith("MOUSE", ignoreCase = true)) {
+            value.setMouseBind(valueIn.split("MOUSE")[1].toInt())
             return
         }
 

--- a/src/main/kotlin/com/lambda/client/setting/settings/impl/other/BindSetting.kt
+++ b/src/main/kotlin/com/lambda/client/setting/settings/impl/other/BindSetting.kt
@@ -25,8 +25,10 @@ class BindSetting(
             value.clear()
             return
         }
-        if (valueIn.startsWith("MOUSE", ignoreCase = true)) {
-            value.setMouseBind(valueIn.split("MOUSE")[1].toInt())
+        if (valueIn.startsWith("Mouse", ignoreCase = true)) {
+            valueIn.split("Mouse").lastOrNull()?.toIntOrNull()?.let {
+                value.setMouseBind(it)
+            }
             return
         }
 

--- a/src/main/kotlin/com/lambda/client/util/Bind.kt
+++ b/src/main/kotlin/com/lambda/client/util/Bind.kt
@@ -21,7 +21,7 @@ class Bind(
 
     private var cachedName = getName()
 
-    val isEmpty get() = key !in 1..255 && compareValues(mouseKey, minMouseButton) <= 0
+    val isEmpty get() = key !in 1..255 && compareValues(mouseKey, minMouseButton) < 0
 
     fun isDown(eventKey: Int): Boolean {
         return eventKey != 0
@@ -108,7 +108,7 @@ class Bind(
             "None"
         } else {
             StringBuilder().run {
-                if (mouseKey != null && mouseKey!! >= minMouseButton) {
+                if (mouseKey != null && mouseKey!! > minMouseButton) {
                     append("MOUSE$mouseKey")
                 } else {
                     for (key in modifierKeys) {
@@ -125,7 +125,7 @@ class Bind(
     }
 
     companion object {
-        const val minMouseButton: Int = 2 // middle click button
+        const val minMouseButton: Int = 2 // middle click button index. Button number = index + 1.
         private val modifierName: Map<Int, String> = hashMapOf(
             Keyboard.KEY_LCONTROL to "Ctrl",
             Keyboard.KEY_RCONTROL to "Ctrl",

--- a/src/main/kotlin/com/lambda/client/util/Bind.kt
+++ b/src/main/kotlin/com/lambda/client/util/Bind.kt
@@ -21,7 +21,7 @@ class Bind(
 
     private var cachedName = getName()
 
-    val isEmpty get() = key !in 1..255 && compareValues(mouseKey, minMouseButton) < 0
+    val isEmpty get() = key !in 1..255 && compareValues(mouseKey, minMouseIndex) < 0
 
     fun isDown(eventKey: Int): Boolean {
         return eventKey != 0
@@ -31,7 +31,7 @@ class Bind(
     }
 
     fun isMouseDown(eventKey: Int): Boolean {
-        return eventKey >= minMouseButton
+        return eventKey > minMouseIndex
             && !isEmpty
             && mouseKey == (eventKey)
     }
@@ -108,7 +108,7 @@ class Bind(
             "None"
         } else {
             StringBuilder().run {
-                if (mouseKey != null && mouseKey!! > minMouseButton) {
+                if (mouseKey != null && mouseKey!! > minMouseIndex) {
                     append("MOUSE$mouseKey")
                 } else {
                     for (key in modifierKeys) {
@@ -125,7 +125,7 @@ class Bind(
     }
 
     companion object {
-        const val minMouseButton: Int = 2 // middle click button index. Button number = index + 1.
+        const val minMouseIndex: Int = 2 // middle click button index. Button number = index + 1.
         private val modifierName: Map<Int, String> = hashMapOf(
             Keyboard.KEY_LCONTROL to "Ctrl",
             Keyboard.KEY_RCONTROL to "Ctrl",

--- a/src/main/kotlin/com/lambda/client/util/Bind.kt
+++ b/src/main/kotlin/com/lambda/client/util/Bind.kt
@@ -108,9 +108,9 @@ class Bind(
             "None"
         } else {
             StringBuilder().run {
-                if (mouseKey != null && mouseKey!! > minMouseIndex) {
-                    append("Mouse$mouseKey")
-                } else {
+                mouseKey?.let {
+                    if (it > minMouseIndex) append("Mouse$mouseKey")
+                } ?: run {
                     for (key in modifierKeys) {
                         val name = modifierName[key] ?: KeyboardUtils.getDisplayName(key) ?: continue
                         append(name)

--- a/src/main/kotlin/com/lambda/client/util/Bind.kt
+++ b/src/main/kotlin/com/lambda/client/util/Bind.kt
@@ -21,7 +21,7 @@ class Bind(
 
     private var cachedName = getName()
 
-    val isEmpty get() = key !in 1..255 && mouseKey == null
+    val isEmpty get() = key !in 1..255 && compareValues(mouseKey, minMouseButton) <= 0
 
     fun isDown(eventKey: Int): Boolean {
         return eventKey != 0
@@ -31,9 +31,9 @@ class Bind(
     }
 
     fun isMouseDown(eventKey: Int): Boolean {
-        return eventKey > 2
+        return eventKey >= minMouseButton
             && !isEmpty
-            && mouseKey == eventKey
+            && mouseKey == (eventKey)
     }
 
     private fun isModifierKeyDown(eventKey: Int, modifierKey: Int) =
@@ -85,7 +85,7 @@ class Bind(
             modifierKeys.clear()
             modifierKeys.addAll(modifierKeysIn)
             key = keyIn
-            mouseKey = 0
+            mouseKey = null
             cachedName = getName()
         }
     }
@@ -94,7 +94,7 @@ class Bind(
         synchronized(this) {
             modifierKeys.clear()
             key = 0
-            mouseKey = 0
+            mouseKey = null
             cachedName = getName()
         }
     }
@@ -108,7 +108,7 @@ class Bind(
             "None"
         } else {
             StringBuilder().run {
-                if (mouseKey != null && mouseKey!! > 2) {
+                if (mouseKey != null && mouseKey!! >= minMouseButton) {
                     append("MOUSE$mouseKey")
                 } else {
                     for (key in modifierKeys) {
@@ -125,6 +125,7 @@ class Bind(
     }
 
     companion object {
+        const val minMouseButton: Int = 2 // middle click button
         private val modifierName: Map<Int, String> = hashMapOf(
             Keyboard.KEY_LCONTROL to "Ctrl",
             Keyboard.KEY_RCONTROL to "Ctrl",

--- a/src/main/kotlin/com/lambda/client/util/Bind.kt
+++ b/src/main/kotlin/com/lambda/client/util/Bind.kt
@@ -109,7 +109,7 @@ class Bind(
         } else {
             StringBuilder().run {
                 if (mouseKey != null && mouseKey!! > minMouseIndex) {
-                    append("MOUSE$mouseKey")
+                    append("Mouse$mouseKey")
                 } else {
                     for (key in modifierKeys) {
                         val name = modifierName[key] ?: KeyboardUtils.getDisplayName(key) ?: continue
@@ -126,6 +126,7 @@ class Bind(
 
     companion object {
         const val minMouseIndex: Int = 2 // middle click button index. Button number = index + 1.
+
         private val modifierName: Map<Int, String> = hashMapOf(
             Keyboard.KEY_LCONTROL to "Ctrl",
             Keyboard.KEY_RCONTROL to "Ctrl",

--- a/src/main/kotlin/com/lambda/client/util/KeyboardUtils.kt
+++ b/src/main/kotlin/com/lambda/client/util/KeyboardUtils.kt
@@ -36,7 +36,7 @@ object KeyboardUtils {
     fun sendUnknownKeyError(bind: String) {
         MessageSendHelper.sendErrorMessage("Unknown key [${formatValue(bind)}]! " +
             "Right shift is ${formatValue("rshift")}, " +
-            "left Control is ${formatValue("lcontrol")}, " +
+            "left control is ${formatValue("lcontrol")}, " +
             "and ` is ${formatValue("grave")}. " +
             "You cannot bind the ${formatValue("meta")} key."
         )


### PR DESCRIPTION
**Describe the pull**

Add mouse key bindings for module toggle states. Bindings are limited to buttons that are not left or right click. 

**Describe how this pull is helpful**

Mouse key bindings allow users to toggle modules without using their keyboard if they have a mouse with additional buttons.

**Additional context**

Existing or added bindings for keyboard bindings are not affected by this and are still allowed.
