### PR TITLE
Removed MixinEntityLivingBase reflection hack

### DIFF
--- a/src/main/java/com/lambda/EntityLivingBaseFireworkHelper.java
+++ b/src/main/java/com/lambda/EntityLivingBaseFireworkHelper.java
@@ -1,0 +1,33 @@
+package com.lambda;
+
+import com.lambda.client.module.modules.movement.ElytraFlight;
+import com.lambda.mixin.accessor.AccessorEntityFireworkRocket;
+import com.lambda.mixin.entity.MixinEntityLivingBase;
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.entity.EntityLivingBase;
+
+/**
+ * Using {@link AccessorEntityFireworkRocket} in {@link MixinEntityLivingBase} causes a crash on older
+ * Mixin versions (like the one Impact uses). Putting the methods using AccessorEntityFireworkRocket outside
+ * the MixinEntityLivingBase seems to fix the issue.
+ */
+public class EntityLivingBaseFireworkHelper {
+    public static boolean shouldWork(EntityLivingBase entity) {
+        return EntityPlayerSP.class.isAssignableFrom(entity.getClass())
+            && ElytraFlight.INSTANCE.isEnabled()
+            && ElytraFlight.INSTANCE.getMode().getValue() == ElytraFlight.ElytraFlightMode.VANILLA;
+    }
+
+    public static boolean shouldModify(EntityLivingBase entity) {
+        return shouldWork(entity) && entity.world.loadedEntityList.stream().anyMatch(firework -> {
+                if (firework instanceof AccessorEntityFireworkRocket) {
+                    EntityLivingBase boosted = ((AccessorEntityFireworkRocket) firework).getBoostedEntity();
+                    return boosted != null && boosted.equals(entity);
+                }
+
+                return false;
+            }
+        );
+    }
+
+}


### PR DESCRIPTION
**Describe the pull**
Removes a reflection hack done in MixinEntityLivingBase to keep compatibility with older Mixin versions.

**Describe how this pull is helpful**
The comment above the hack describes it as `a bit silly and bad for performance` which is fixed here.

**Additional context**
The reason the hack was added is because Mixin did not have [this](https://github.com/SpongePowered/Mixin/blob/155314e6e91465dad727e621a569906a410cd6f4/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java#L985) line prior to 0.8. In Mixin 0.7 the check `typeInfo.isLoadable()` (which would check if AccessorEntityFireworkRocket is an Accessor) did not exist, causing Mixin to try to find the class in the hierachy of EntityLivingBase. This only happens when a Mixin method is merged into the targeted class, and only for the methods of that Mixin class, so putting the methods inside a helper class fixes the issue. 

Let me know if this is wanted and if the helper class should be a kotlin class instead.
