### PR TITLE
Update Baritone.kt

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/modules/client/Baritone.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/client/Baritone.kt
@@ -26,6 +26,8 @@ object Baritone : Module(
     private val allowPlace by setting("Allow Place", true)
     private val allowInventory by setting("Allow Inventory", false)
     private val freeLook by setting("Free Look", true)
+    private val allowWaterBucketFall by setting("Water bucket clutch", true, description = "Uses a water bucket to get down quickly.")
+    private val maxFallHeightBucket by setting("Max bucket height", 20, 5..255, 5, { allowWaterBucketFall }, description = "Max height that baritone can use a water bucket.")
     private val allowDownwardTunneling by setting("Downward Tunneling", true)
     private val allowParkour by setting("Allow Parkour", true)
     private val allowParkourPlace by setting("Allow Parkour Place", true)
@@ -75,6 +77,8 @@ object Baritone : Module(
             it.allowPlace.value = allowPlace
             it.allowInventory.value = allowInventory
             it.freeLook.value = freeLook
+            it.allowWaterBucketFall.value = allowWaterBucketFall
+            it.maxFallHeightBucket.value = maxFallHeightBucket
             it.allowDownward.value = allowDownwardTunneling
             it.allowParkour.value = allowParkour
             it.allowParkourPlace.value = allowParkourPlace


### PR DESCRIPTION
Adds Water bucket clutch with Max bucket height

**Describe the pull**
This pull request adds the baritone setting allowWaterBucketFall called "Water bucket clutch", as a GUI option. This can be true or false but is defaulted to true. The description is "Uses a water bucket to get down quickly". In relation to the first, maxFallHeightBucket in baritone, is added as a GUI option called "Max bucket height". This option can be set to 5 to 255 blocks by implements of 5. It's defaulted to 20. This option only shows up if "Water bucket clutch" is true. The description is "Max height that baritone can use a water bucket".

**Describe how this pull is helpful**
This is a GUI option, Water bucket clutch, for baritone. The setting can be changed in CLI but this makes it easier.

**Additional context**