### PR TITLE
Migrated to new UUID to name conversion API

### DIFF
--- a/src/main/kotlin/com/lambda/client/capeapi/AbstractUUIDManager.kt
+++ b/src/main/kotlin/com/lambda/client/capeapi/AbstractUUIDManager.kt
@@ -95,7 +95,7 @@ abstract class AbstractUUIDManager(
     }
 
     private fun requestProfileFromUUID(uuid: String): String? {
-        return request("https://sessionserver.mojang.com/session/profile/${UUIDUtils.removeDashes(uuid)}")
+        return request("https://sessionserver.mojang.com/session/minecraft/profile/${UUIDUtils.removeDashes(uuid)}")
     }
 
     private fun requestProfileFromName(name: String): String? {

--- a/src/main/kotlin/com/lambda/client/capeapi/AbstractUUIDManager.kt
+++ b/src/main/kotlin/com/lambda/client/capeapi/AbstractUUIDManager.kt
@@ -80,7 +80,7 @@ abstract class AbstractUUIDManager(
             try {
                 val jsonElement = parser.parse(response)
                 if (isUUID) {
-                    val name = jsonElement.asJsonArray.last().asJsonObject["name"].asString
+                    val name = jsonElement.asJsonObject["name"].asString
                     PlayerProfile(UUID.fromString(nameOrUUID), name)
                 } else {
                     val id = jsonElement.asJsonObject["id"].asString
@@ -95,7 +95,7 @@ abstract class AbstractUUIDManager(
     }
 
     private fun requestProfileFromUUID(uuid: String): String? {
-        return request("https://api.mojang.com/user/profiles/${UUIDUtils.removeDashes(uuid)}/names")
+        return request("https://sessionserver.mojang.com/session/profile/${UUIDUtils.removeDashes(uuid)}")
     }
 
     private fun requestProfileFromName(name: String): String? {


### PR DESCRIPTION
**Describe the pull**
Mojang disabled the [name history API](https://wiki.vg/Mojang_API#UUID_to_Name_History_.28Removed.29) on 13 September 2022.
This broke how Lambda gets player names from UUID's, which then breaks modules like MobOwner.

**Describe how this pull is helpful**
Migrated to the [Profile API](https://wiki.vg/Mojang_API#Profile_Information) to get player name from UUID.

**Additional context**
There are probably a few third party API's that could be migrated to with higher rate limiting or to still get name history but mojang api is fine for this use case.
