### PR TITLE
fix unfocused clickgui issue

### DIFF
--- a/src/main/java/com/lambda/mixin/accessor/gui/AccessorGuiScreen.java
+++ b/src/main/java/com/lambda/mixin/accessor/gui/AccessorGuiScreen.java
@@ -1,0 +1,12 @@
+package com.lambda.mixin.accessor.gui;
+
+import net.minecraft.client.gui.GuiScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(value = GuiScreen.class)
+public interface AccessorGuiScreen {
+
+    @Accessor("eventButton")
+    void setEventButton(final int eventButton);
+}

--- a/src/main/kotlin/com/lambda/client/gui/AbstractLambdaGui.kt
+++ b/src/main/kotlin/com/lambda/client/gui/AbstractLambdaGui.kt
@@ -15,6 +15,7 @@ import com.lambda.client.util.graphics.font.FontRenderAdapter
 import com.lambda.client.util.math.Vec2d
 import com.lambda.client.util.math.Vec2f
 import com.lambda.client.util.threads.safeListener
+import com.lambda.mixin.accessor.gui.AccessorGuiScreen
 import net.minecraft.client.gui.GuiScreen
 import net.minecraft.client.gui.ScaledResolution
 import net.minecraft.client.renderer.GlStateManager
@@ -140,6 +141,7 @@ abstract class AbstractLambdaGui<S : SettingWindow<*>, E : Any> : GuiScreen() {
     open fun onDisplayed() {
         lastClickedWindow = null
         lastEventButton = -1
+        (this as AccessorGuiScreen).setEventButton(-1)
 
         displayed.value = true
 

--- a/src/main/resources/mixins.lambda.json
+++ b/src/main/resources/mixins.lambda.json
@@ -18,6 +18,7 @@
     "accessor.gui.AccessorGuiChat",
     "accessor.gui.AccessorGuiDisconnected",
     "accessor.gui.AccessorGuiEditSign",
+    "accessor.gui.AccessorGuiScreen",
     "accessor.network.AccessorCPacketChatMessage",
     "accessor.network.AccessorCPacketCloseWindow",
     "accessor.network.AccessorCPacketPlayer",


### PR DESCRIPTION
**Describe the pull**
to reproduce issue without this commit:

1. clickgui -> hudeditor gui
2. close clickgui
3. open clickgui

**Describe how this pull is helpful**
Issue caused by mouse getting stuck in the DRAG state even when no button was being clicked.
`handleMouseInput` in `GuiScreen` never resets this variable until it gets a new mouse click, causing gui's to get a stale mouse button value until the next click

**Additional context**
trolled by MC's GuiScreen
didn't find any other way to reset this private variable without an accessor unfortunately.
another option would be to mixin and reset this var in  `GuiScreen.onGuiClosed` but not sure if there's other gui's that depend on this existing behavior.
