### PR TITLE
Changed Baritone and efly defaults

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/modules/client/Baritone.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/client/Baritone.kt
@@ -54,7 +54,6 @@ object Baritone : Module(
     private val blockReachDistance by setting("Reach Distance", 4.5f, 1.0f..10.0f, 0.5f, { page == Page.ADVANCED }, description = "Max distance baritone can place blocks.")
     private val enterPortals by setting("Enter Portals", true, { page == Page.ADVANCED }, description = "Baritone will walk all the way into the portal, instead of stopping one block before.")
     private val blockPlacementPenalty by setting("Block Placement Penalty", 20, 0..40, 5, { page == Page.ADVANCED }, description = "Decrease to make Baritone more often consider paths that would require placing blocks.")
-    private val blockBreakAdditionalPenalty by setting("Block Break Additional Penalty", 2, 0..10, 1, { page == Page.ADVANCED }, description = "Lower chance to break blocks. This is a tiebreaker.")
     private val jumpPenalty by setting("Jump Penalty", 2, 0..10, 1, { page == Page.ADVANCED }, description = "Additional penalty for hitting the space bar (ascend, pillar, or parkour) because it uses hunger.")
     private val assumeWalkOnWater by setting("Assume Walk On Water", false, { page == Page.ADVANCED }, description = "Allow Baritone to assume it can walk on still water just like any other block. Requires jesus to be enabled.")
     private val failureTimeout by setting("Fail Timeout", 2, 1..20, 1, { page == Page.ADVANCED }, unit = "s")
@@ -127,7 +126,6 @@ object Baritone : Module(
             it.blockReachDistance.value = blockReachDistance
             it.enterPortal.value = enterPortals
             it.blockPlacementPenalty.value = blockPlacementPenalty.toDouble()
-            it.blockBreakAdditionalPenalty.value = blockBreakAdditionalPenalty.toDouble()
             it.jumpPenalty.value = jumpPenalty.toDouble()
             it.assumeWalkOnWater.value = assumeWalkOnWater
             it.failureTimeoutMS.value = failureTimeout * 1000L

--- a/src/main/kotlin/com/lambda/client/module/modules/movement/ElytraFlight.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/ElytraFlight.kt
@@ -48,7 +48,7 @@ object ElytraFlight : Module(
     private val easyTakeOff by setting("Easy Takeoff", true, { page == Page.GENERIC_SETTINGS })
     private val timerControl by setting("Takeoff Timer", true, { easyTakeOff && page == Page.GENERIC_SETTINGS })
     private val highPingOptimize by setting("High Ping Optimize", false, { easyTakeOff && page == Page.GENERIC_SETTINGS })
-    private val minTakeoffHeight by setting("Min Takeoff Height", 0.5f, 0.0f..1.5f, 0.1f, { easyTakeOff && !highPingOptimize && page == Page.GENERIC_SETTINGS })
+    private val minTakeoffHeight by setting("Min Takeoff Height", 1.2f, 0.0f..1.5f, 0.1f, { easyTakeOff && !highPingOptimize && page == Page.GENERIC_SETTINGS })
 
     /* Acceleration */
     private val accelerateStartSpeed by setting("Start Speed", 100, 0..100, 5, { mode.value != ElytraFlightMode.BOOST && mode.value != ElytraFlightMode.VANILLA && page == Page.GENERIC_SETTINGS })
@@ -68,8 +68,8 @@ object ElytraFlight : Module(
     /* Mode Settings */
     /* Boost */
     private val speedBoost by setting("Speed B", 1.0f, 0.0f..10.0f, 0.1f, { mode.value == ElytraFlightMode.BOOST && page == Page.MODE_SETTINGS })
-    private val upSpeedBoost by setting("Up Speed B", 1.0f, 1.0f..5.0f, 0.1f, { mode.value == ElytraFlightMode.BOOST && page == Page.MODE_SETTINGS })
-    private val downSpeedBoost by setting("Down Speed B", 1.0f, 1.0f..5.0f, 0.1f, { mode.value == ElytraFlightMode.BOOST && page == Page.MODE_SETTINGS })
+    private val upSpeedBoost by setting("Up Speed B", 1.0f, 0.0f..5.0f, 0.1f, { mode.value == ElytraFlightMode.BOOST && page == Page.MODE_SETTINGS })
+    private val downSpeedBoost by setting("Down Speed B", 1.0f, 0.0f..5.0f, 0.1f, { mode.value == ElytraFlightMode.BOOST && page == Page.MODE_SETTINGS })
 
     /* Control */
     private val boostPitchControl by setting("Base Boost Pitch", 20, 0..90, 5, { mode.value == ElytraFlightMode.CONTROL && page == Page.MODE_SETTINGS })
@@ -95,8 +95,8 @@ object ElytraFlight : Module(
 
 
     /* Vanilla */
-    private val upPitch by setting("Up Pitch", 50f, 0f..90f, 5f, { mode.value == ElytraFlightMode.VANILLA && page == Page.MODE_SETTINGS })
-    private val downPitch by setting("Down Pitch", 30f, 0f..90f, 5f, { mode.value == ElytraFlightMode.VANILLA && page == Page.MODE_SETTINGS })
+    private val upPitch by setting("Up Pitch", 20f, 0f..90f, 5f, { mode.value == ElytraFlightMode.VANILLA && page == Page.MODE_SETTINGS })
+    private val downPitch by setting("Down Pitch", 0f, 0f..90f, 5f, { mode.value == ElytraFlightMode.VANILLA && page == Page.MODE_SETTINGS })
     private val rocketPitch by setting("Rocket Pitch", 50f, 0f..90f, 5f, { mode.value == ElytraFlightMode.VANILLA && page == Page.MODE_SETTINGS })
 
     /* End of Mode Settings */

--- a/src/main/kotlin/com/lambda/client/module/modules/movement/ElytraFlight.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/ElytraFlight.kt
@@ -95,7 +95,7 @@ object ElytraFlight : Module(
 
 
     /* Vanilla */
-    private val upPitch by setting("Up Pitch", 20f, 0f..90f, 5f, { mode.value == ElytraFlightMode.VANILLA && page == Page.MODE_SETTINGS })
+    private val upPitch by setting("Up Pitch", 30f, 0f..90f, 5f, { mode.value == ElytraFlightMode.VANILLA && page == Page.MODE_SETTINGS })
     private val downPitch by setting("Down Pitch", 0f, 0f..90f, 5f, { mode.value == ElytraFlightMode.VANILLA && page == Page.MODE_SETTINGS })
     private val rocketPitch by setting("Rocket Pitch", 50f, 0f..90f, 5f, { mode.value == ElytraFlightMode.VANILLA && page == Page.MODE_SETTINGS })
 


### PR DESCRIPTION
**Describe the pull**
<!-- A clear and concise description of what the pull is for. -->
* Removed "Block Break Additional Penalty" I thought it would control Block Break Penalty. My mistake for adding this.
* Changed "Min Takeoff Height" default to 1.2 so it takes off at the end of the jump.
* Boost settings can be changed to 0 effectively disabling it. Useful for easy takeoff only.
* Vanilla auto pitch values have been changed for more efficient flights.

**Describe how this pull is helpful**
<!-- A clear description of why this should be merged -->

**Additional context**
<!-- Add any other context about the pull here. -->
This is not efly without rockets.