### PR TITLE
fixed problems with locked plugin-jars on windows

### DIFF
--- a/src/main/kotlin/com/lambda/client/LambdaCoreMod.kt
+++ b/src/main/kotlin/com/lambda/client/LambdaCoreMod.kt
@@ -34,7 +34,7 @@ class LambdaCoreMod : IFMLLoadingPlugin {
         MixinBootstrap.init()
         Mixins.addConfigurations("mixins.lambda.json", "mixins.baritone.json")
 
-        PluginManager.getLoaders()
+        PluginManager.checkPluginLoaders(PluginManager.getLoaders())
             .filter { it.info.mixins.isNotEmpty() }
             .forEach {
                 logger.info("Initialised mixins of ${it.info.name}.")

--- a/src/main/kotlin/com/lambda/client/plugin/PluginError.kt
+++ b/src/main/kotlin/com/lambda/client/plugin/PluginError.kt
@@ -7,6 +7,7 @@ import java.io.File
 internal enum class PluginError {
     HOT_RELOAD,
     DUPLICATE,
+    DEPRECATED,
     UNSUPPORTED,
     REQUIRED_PLUGIN,
     OUTDATED_PLUGIN,
@@ -22,6 +23,9 @@ internal enum class PluginError {
             }
             DUPLICATE -> {
                 log("Duplicate plugin $loader.")
+            }
+            DEPRECATED -> {
+                log("Plugin $loader is deprecated due to the presence of a newer version: $message")
             }
             UNSUPPORTED -> {
                 log("Unsupported plugin $loader. Minimum required Lambda version: ${loader.info.minApiVersion}")
@@ -46,7 +50,15 @@ internal enum class PluginError {
             }
         }
 
-        loader.file.renameTo(File("${loader.file.path}.disabled"))
+        // append .disabled to the file name
+        // if a file with the same name exists, append a number to the end
+        var disabledFile = File("${loader.file.path}.disabled")
+        var i = 1
+        while (disabledFile.exists()) {
+            disabledFile = File("${loader.file.path}.disabled$i")
+            i++
+        }
+        loader.file.renameTo(disabledFile)
     }
 
     fun log(message: String?, throwable: Throwable? = null) {


### PR DESCRIPTION
This pull request addresses issues with plugin jars becoming locked on Windows systems, preventing the plugins from being updated or removed. The changes included in this pull request resolve the problem by disabling deprecated jars before loading them.