### PR TITLE
Window resize handle indication and scroll fix

### DIFF
--- a/src/main/kotlin/com/lambda/client/gui/AbstractLambdaGui.kt
+++ b/src/main/kotlin/com/lambda/client/gui/AbstractLambdaGui.kt
@@ -45,7 +45,7 @@ abstract class AbstractLambdaGui<S : SettingWindow<*>, E : Any> : GuiScreen() {
 
     // Mouse
     private var lastEventButton = -1
-    private var lastClickPos = Vec2f(0.0f, 0.0f)
+    private var lastClickPos = Vec2f.ZERO
 
     // Searching
     protected var typedString = ""
@@ -285,8 +285,6 @@ abstract class AbstractLambdaGui<S : SettingWindow<*>, E : Any> : GuiScreen() {
         drawTypedString()
 
         GlStateUtils.depth(false)
-
-        hoveredWindow?.onMouseInput(getRealMousePos())
     }
 
     private fun drawBackground(vertexHelper: VertexHelper, partialTicks: Float) {

--- a/src/main/kotlin/com/lambda/client/gui/AbstractLambdaGui.kt
+++ b/src/main/kotlin/com/lambda/client/gui/AbstractLambdaGui.kt
@@ -198,6 +198,7 @@ abstract class AbstractLambdaGui<S : SettingWindow<*>, E : Any> : GuiScreen() {
             }
         }
 
+        hoveredWindow?.onMouseInput(mousePos)
         super.handleMouseInput()
         updateSettingWindow()
     }

--- a/src/main/kotlin/com/lambda/client/gui/clickgui/LambdaClickGui.kt
+++ b/src/main/kotlin/com/lambda/client/gui/clickgui/LambdaClickGui.kt
@@ -41,7 +41,7 @@ object LambdaClickGui : AbstractLambdaGui<ModuleSettingWindow, AbstractModule>()
         var posX = 0.0f
 
         Category.values().forEach { category ->
-            val window = ListWindow(category.displayName, posX, 0.0f, 90.0f, 300.0f, Component.SettingGroup.CLICK_GUI)
+            val window = ListWindow(category.displayName, posX, 0.0f, 90.0f, 300.0f, Component.SettingGroup.CLICK_GUI, drawHandle = true)
             windows.add(window)
 
             posX += 90.0f

--- a/src/main/kotlin/com/lambda/client/gui/clickgui/component/PluginWindow.kt
+++ b/src/main/kotlin/com/lambda/client/gui/clickgui/component/PluginWindow.kt
@@ -6,7 +6,7 @@ class PluginWindow(
     cname: String,
     cPosX: Float,
     cPosY: Float,
-) : ListWindow(cname, cPosX, cPosY, 120.0f, 200.0f, SettingGroup.CLICK_GUI) {
+) : ListWindow(cname, cPosX, cPosY, 120.0f, 200.0f, SettingGroup.CLICK_GUI, drawHandle = true) {
     override val minHeight: Float
         get() = 100.0f
 }

--- a/src/main/kotlin/com/lambda/client/module/modules/client/ClickGUI.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/client/ClickGUI.kt
@@ -32,7 +32,7 @@ object ClickGUI : Module(
     val fadeInTime by setting("Fade In Time", 0.25f, 0.0f..1.0f, 0.05f, unit = "s")
     val fadeOutTime by setting("Fade Out Time", 0.1f, 0.0f..1.0f, 0.05f, unit = "s")
     val scrollRubberband by setting("Scroll Rubberband", false)
-    val scrollRubberbandSpeed by setting("Scroll Rubberband Speed", 0.5f, 0.01f..1.0f, 0.05f, { scrollRubberband })
+    val scrollRubberbandSpeed by setting("Scroll Rubberband Speed", 0.25f, 0.01f..1.0f, 0.05f, { scrollRubberband })
     val showModifiedInBold by setting("Show Modified In Bold", false, description = "Display modified settings in a bold font")
     private val resetComponents = setting("Reset Positions", false)
     private val resetScale = setting("Reset Scale", false)


### PR DESCRIPTION
The default value for the rubberbanding speed has been set to be equal to lambda 3.2.1 (0.25)
Dots have been added to the module window resize handles for improved visual design.
The scrolling and rubberbanding behaviour was broken by a previous commit and is now partly fixed.