### PR TITLE
improved packet logging for entity movement and player list

### DIFF
--- a/src/main/java/com/lambda/mixin/accessor/network/AccessorSPacketEntity.java
+++ b/src/main/java/com/lambda/mixin/accessor/network/AccessorSPacketEntity.java
@@ -1,0 +1,17 @@
+package com.lambda.mixin.accessor.network;
+
+import net.minecraft.network.play.server.SPacketEntity;
+import net.minecraft.network.play.server.SPacketEntityVelocity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(SPacketEntity.class)
+public interface AccessorSPacketEntity {
+
+    @Accessor("entityId")
+    int getEntityId();
+
+    @Accessor("entityId")
+    void setEntityId(int value);
+
+}

--- a/src/main/java/com/lambda/mixin/accessor/network/AccessorSPacketEntityHeadLook.java
+++ b/src/main/java/com/lambda/mixin/accessor/network/AccessorSPacketEntityHeadLook.java
@@ -1,0 +1,16 @@
+package com.lambda.mixin.accessor.network;
+
+import net.minecraft.network.play.server.SPacketEntityHeadLook;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(SPacketEntityHeadLook.class)
+public interface AccessorSPacketEntityHeadLook {
+
+    @Accessor("entityId")
+    int getEntityId();
+
+    @Accessor("entityId")
+    void setEntityId(int value);
+
+}

--- a/src/main/kotlin/com/lambda/client/mixin/extension/Network.kt
+++ b/src/main/kotlin/com/lambda/client/mixin/extension/Network.kt
@@ -5,10 +5,7 @@ import net.minecraft.network.play.client.CPacketChatMessage
 import net.minecraft.network.play.client.CPacketCloseWindow
 import net.minecraft.network.play.client.CPacketPlayer
 import net.minecraft.network.play.client.CPacketUseEntity
-import net.minecraft.network.play.server.SPacketChat
-import net.minecraft.network.play.server.SPacketEntityVelocity
-import net.minecraft.network.play.server.SPacketExplosion
-import net.minecraft.network.play.server.SPacketPlayerPosLook
+import net.minecraft.network.play.server.*
 import net.minecraft.util.text.ITextComponent
 
 var CPacketChatMessage.chatMessage: String
@@ -113,4 +110,16 @@ var SPacketPlayerPosLook.playerPosLookPitch: Float
     get() = this.pitch
     set(value) {
         (this as AccessorSPacketPosLook).setPitch(value)
+    }
+
+var SPacketEntity.entityId: Int
+    get() = (this as AccessorSPacketEntity).entityId
+    set(value) {
+        (this as AccessorSPacketEntity).entityId = value
+    }
+
+var SPacketEntityHeadLook.entityHeadLookEntityId: Int
+    get() = (this as AccessorSPacketEntityHeadLook).entityId
+    set(value) {
+        (this as AccessorSPacketEntityHeadLook).entityId = value
     }

--- a/src/main/kotlin/com/lambda/client/module/modules/player/PacketLogger.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/player/PacketLogger.kt
@@ -550,6 +550,28 @@ object PacketLogger : Module(
                         }
                     }
                 }
+                is SPacketPlayerListItem -> {
+                    logServer(packet) {
+                        "action" to packet.action.name
+                        "entries" to buildString {
+                            for (entry in packet.entries) {
+                                append("> displayName: ")
+                                append(entry.displayName)
+                                append(" gameMode: ")
+                                append(entry.gameMode?.name)
+                                append(" ping: ")
+                                append(entry.ping)
+                                append(" profile.id: ")
+                                append(entry.profile?.id)
+                                append(" profile.name: ")
+                                append(entry.profile?.name)
+                                append(" profile.properties: ")
+                                append(entry.profile?.properties)
+                                append(' ')
+                            }
+                        }
+                    }
+                }
                 is SPacketSoundEffect -> {
                     logServer(packet) {
                         "sound" to packet.sound.soundName

--- a/src/main/kotlin/com/lambda/client/module/modules/player/PacketLogger.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/player/PacketLogger.kt
@@ -589,6 +589,17 @@ object PacketLogger : Module(
                         "data" to packet.data
                     }
                 }
+                is SPacketSpawnPlayer -> {
+                    logServer(packet) {
+                        "entityID" to packet.entityID
+                        "uniqueID" to packet.uniqueId
+                        "x" to packet.x
+                        "y" to packet.y
+                        "z" to packet.z
+                        "yaw" to packet.yaw
+                        "pitch" to packet.pitch
+                    }
+                }
                 is SPacketTeams -> {
                     logServer(packet) {
                         "action" to packet.action

--- a/src/main/kotlin/com/lambda/client/module/modules/player/PacketLogger.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/player/PacketLogger.kt
@@ -8,7 +8,6 @@ import com.lambda.client.event.listener.listener
 import com.lambda.client.mixin.extension.*
 import com.lambda.client.module.Category
 import com.lambda.client.module.Module
-import com.lambda.client.module.modules.misc.MapDownloader.setting
 import com.lambda.client.util.FolderUtils
 import com.lambda.client.util.TickTimer
 import com.lambda.client.util.TimeUnit
@@ -43,6 +42,7 @@ object PacketLogger : Module(
     private val ignoreUnknown by setting("Ignore Unknown Packets", false, description = "Ignore packets that aren't explicitly handled.")
     private val ignoreChat by setting("Ignore Chat", true, description = "Ignore chat packets.")
     private val ignoreCancelled by setting("Ignore Cancelled", true, description = "Ignore cancelled packets.")
+    private val ignorePlayerPosition by setting("Ignore Player Position", false, description = "Ignore sent position & rotation packets.")
     private val openLogFolder by setting("Open Log Folder...", false, consumer = { _, _ ->
         FolderUtils.openFolder(FolderUtils.packetLogFolder)
         true
@@ -652,33 +652,41 @@ object PacketLogger : Module(
                     }
                 }
                 is CPacketPlayer.Rotation -> {
-                    logClient(packet) {
-                        "yaw" to packet.playerYaw
-                        "pitch" to packet.playerPitch
-                        "onGround" to packet.isOnGround
+                    if (!ignorePlayerPosition) {
+                        logClient(packet) {
+                            "yaw" to packet.playerYaw
+                            "pitch" to packet.playerPitch
+                            "onGround" to packet.isOnGround
+                        }
                     }
                 }
                 is CPacketPlayer.Position -> {
-                    logClient(packet) {
-                        "x" to packet.playerX
-                        "y" to packet.playerY
-                        "z" to packet.playerZ
-                        "onGround" to packet.isOnGround
+                    if (!ignorePlayerPosition) {
+                        logClient(packet) {
+                            "x" to packet.playerX
+                            "y" to packet.playerY
+                            "z" to packet.playerZ
+                            "onGround" to packet.isOnGround
+                        }
                     }
                 }
                 is CPacketPlayer.PositionRotation -> {
-                    logClient(packet) {
-                        "x" to packet.playerX
-                        "y" to packet.playerY
-                        "z" to packet.playerZ
-                        "yaw" to packet.playerYaw
-                        "pitch" to packet.playerPitch
-                        "onGround" to packet.isOnGround
+                    if (!ignorePlayerPosition) {
+                        logClient(packet) {
+                            "x" to packet.playerX
+                            "y" to packet.playerY
+                            "z" to packet.playerZ
+                            "yaw" to packet.playerYaw
+                            "pitch" to packet.playerPitch
+                            "onGround" to packet.isOnGround
+                        }
                     }
                 }
                 is CPacketPlayer -> {
-                    logClient(packet) {
-                        "onGround" to packet.isOnGround
+                    if (!ignorePlayerPosition) {
+                        logClient(packet) {
+                            "onGround" to packet.isOnGround
+                        }
                     }
                 }
                 is CPacketPlayerDigging -> {

--- a/src/main/kotlin/com/lambda/client/module/modules/player/PacketLogger.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/player/PacketLogger.kt
@@ -43,6 +43,7 @@ object PacketLogger : Module(
     private val ignoreChat by setting("Ignore Chat", true, description = "Ignore chat packets.")
     private val ignoreCancelled by setting("Ignore Cancelled", true, description = "Ignore cancelled packets.")
     private val ignorePlayerPosition by setting("Ignore Player Position", false, description = "Ignore sent position & rotation packets.")
+    private val ignoreTimeUpdates by setting("Ignore Time Updates", false, description = "Ignore time update packets.")
     private val openLogFolder by setting("Open Log Folder...", false, consumer = { _, _ ->
         FolderUtils.openFolder(FolderUtils.packetLogFolder)
         true
@@ -308,8 +309,39 @@ object PacketLogger : Module(
                         "isSoundServerwide" to packet.isSoundServerwide
                     }
                 }
+                is SPacketEntity.S15PacketEntityRelMove -> {
+                    logServer(packet) {
+                        "entityId" to packet.entityId
+                        "x" to packet.x
+                        "y" to packet.y
+                        "z" to packet.z
+                        "onGround" to packet.onGround
+                    }
+                }
+                is SPacketEntity.S16PacketEntityLook -> {
+                    logServer(packet) {
+                        "entityId" to packet.entityId
+                        "yaw" to packet.yaw
+                        "pitch" to packet.pitch
+                        "isRotating" to packet.isRotating
+                        "onGround" to packet.onGround
+                    }
+                }
+                is SPacketEntity.S17PacketEntityLookMove -> {
+                    logServer(packet) {
+                        "entityId" to packet.entityId
+                        "x" to packet.x
+                        "y" to packet.y
+                        "z" to packet.z
+                        "yaw" to packet.yaw
+                        "pitch" to packet.pitch
+                        "isRotating" to packet.isRotating
+                        "onGround" to packet.onGround
+                    }
+                }
                 is SPacketEntity -> {
                     logServer(packet) {
+                        "entityId" to packet.entityId
                         "x" to packet.x
                         "y" to packet.y
                         "z" to packet.z
@@ -344,6 +376,7 @@ object PacketLogger : Module(
                 }
                 is SPacketEntityHeadLook -> {
                     logServer(packet) {
+                        "entityId" to packet.entityHeadLookEntityId
                         "yaw" to packet.yaw
                     }
                 }
@@ -378,12 +411,12 @@ object PacketLogger : Module(
                 }
                 is SPacketEntityTeleport -> {
                     logServer(packet) {
+                        "entityID" to packet.entityId
                         "x" to packet.x
                         "y" to packet.y
                         "z" to packet.z
                         "yaw" to packet.yaw
                         "pitch" to packet.pitch
-                        "entityID" to packet.entityId
                     }
                 }
                 is SPacketEntityVelocity -> {
@@ -542,9 +575,11 @@ object PacketLogger : Module(
                     }
                 }
                 is SPacketTimeUpdate -> {
-                    logServer(packet) {
-                        "totalWorldTime" to packet.totalWorldTime
-                        "worldTime" to packet.worldTime
+                    if (!ignoreTimeUpdates) {
+                        logServer(packet) {
+                            "totalWorldTime" to packet.totalWorldTime
+                            "worldTime" to packet.worldTime
+                        }
                     }
                 }
                 is SPacketUnloadChunk -> {
@@ -579,17 +614,6 @@ object PacketLogger : Module(
                         "slot" to packet.slot
                         "stack" to packet.stack.displayName
                         "windowId" to packet.windowId
-                    }
-                }
-                is SPacketEntity.S15PacketEntityRelMove -> {
-                    logServer(packet) {
-                        "x" to packet.x
-                        "y" to packet.y
-                        "z" to packet.z
-                        "yaw" to packet.yaw
-                        "pitch" to packet.pitch
-                        "isRotating" to packet.isRotating
-                        "onGround" to packet.onGround
                     }
                 }
                 else -> {

--- a/src/main/resources/mixins.lambda.json
+++ b/src/main/resources/mixins.lambda.json
@@ -27,6 +27,8 @@
     "accessor.network.AccessorSPacketEntityVelocity",
     "accessor.network.AccessorSPacketExplosion",
     "accessor.network.AccessorSPacketPosLook",
+    "accessor.network.AccessorSPacketEntity",
+    "accessor.network.AccessorSPacketEntityHeadLook",
     "accessor.player.AccessorEntityPlayerSP",
     "accessor.player.AccessorPlayerControllerMP",
     "accessor.render.AccessorRenderGlobal",


### PR DESCRIPTION
Several additions to the packet logger:
- separately logging S15PacketEntityRelMove, S16PacketEntityLook, S17PacketEntityLookMove
- including entityId for entity-movement related packets, added respective accessors and mixins
- added SPacketPlayerListItem and SPacketSpawnPlayer to be recognized and logged
- new option to ignore player movement packets (because they are also sent while standing still)
- new option to ignore Time Update packets from the server