### PR TITLE
ChestStealer Rusherhack compat

### DIFF
--- a/src/main/java/com/lambda/mixin/gui/MixinGuiContainer.java
+++ b/src/main/java/com/lambda/mixin/gui/MixinGuiContainer.java
@@ -12,43 +12,43 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.io.IOException;
-
 @Mixin(GuiContainer.class)
 public class MixinGuiContainer extends GuiScreen {
 
     @Shadow protected int guiLeft;
     @Shadow protected int guiTop;
     @Shadow protected int xSize;
-
     private final GuiButton stealButton = new LambdaGuiStealButton(this.guiLeft + this.xSize + 2, this.guiTop + 2);
     private final GuiButton storeButton = new LambdaGuiStoreButton(this.guiLeft + this.xSize + 2, this.guiTop + 4 + stealButton.height);
 
-    @Inject(method = "initGui", at = @At("HEAD"))
-    public void initGui(CallbackInfo ci) {
-        if (ChestStealer.INSTANCE.isValidGui()) {
-            this.buttonList.add(stealButton);
-            this.buttonList.add(storeButton);
-            ChestStealer.updateButton(stealButton, this.guiLeft, this.xSize, this.guiTop);
-            ChestStealer.updateButton(storeButton, this.guiLeft, this.xSize, this.guiTop);
+    @Inject(method = "mouseClicked", at = @At("TAIL"))
+    public void mouseClicked(int x, int y, int button, CallbackInfo ci) {
+        if (button == 0) {
+            if (storeButton.mousePressed(mc, x, y)) {
+                ChestStealer.INSTANCE.setStoring(!ChestStealer.INSTANCE.getStoring());
+            } else if (stealButton.mousePressed(mc, x, y)) {
+                ChestStealer.INSTANCE.setStealing(!ChestStealer.INSTANCE.getStealing());
+            }
         }
     }
 
-    @Override
-    protected void actionPerformed(GuiButton button) throws IOException {
-        if (button.id == 696969) {
-            ChestStealer.INSTANCE.setStealing(!ChestStealer.INSTANCE.getStealing());
-        } else if (button.id == 420420) {
-            ChestStealer.INSTANCE.setStoring(!ChestStealer.INSTANCE.getStoring());
-        } else {
-            super.actionPerformed(button);
-        }
-    }
-
-    @Inject(method = "updateScreen", at = @At("HEAD"))
+    @Inject(method = "updateScreen", at = @At("TAIL"))
     public void updateScreen(CallbackInfo ci) {
-        ChestStealer.updateButton(stealButton, this.guiLeft, this.xSize, this.guiTop);
-        ChestStealer.updateButton(storeButton, this.guiLeft, this.xSize, this.guiTop);
+        if (ChestStealer.INSTANCE.isValidGui()) {
+            if (ChestStealer.INSTANCE.isEnabled()) {
+                if (!this.buttonList.contains(stealButton)) {
+                    this.buttonList.add(stealButton);
+                }
+                if (!this.buttonList.contains(storeButton)) {
+                    this.buttonList.add(storeButton);
+                }
+                ChestStealer.updateButton(stealButton, this.guiLeft, this.xSize, this.guiTop);
+                ChestStealer.updateButton(storeButton, this.guiLeft, this.xSize, this.guiTop);
+            } else {
+                this.buttonList.remove(storeButton);
+                this.buttonList.remove(storeButton);
+            }
+        }
     }
 
 }

--- a/src/main/java/com/lambda/mixin/gui/MixinGuiContainer.java
+++ b/src/main/java/com/lambda/mixin/gui/MixinGuiContainer.java
@@ -18,37 +18,39 @@ public class MixinGuiContainer extends GuiScreen {
     @Shadow protected int guiLeft;
     @Shadow protected int guiTop;
     @Shadow protected int xSize;
-    private final GuiButton stealButton = new LambdaGuiStealButton(this.guiLeft + this.xSize + 2, this.guiTop + 2);
-    private final GuiButton storeButton = new LambdaGuiStoreButton(this.guiLeft + this.xSize + 2, this.guiTop + 4 + stealButton.height);
+    private final GuiButton stealButton = new LambdaGuiStealButton(guiLeft + xSize + 2, guiTop + 2);
+    private final GuiButton storeButton = new LambdaGuiStoreButton(guiLeft + xSize + 2, guiTop + 4 + stealButton.height);
 
     @Inject(method = "mouseClicked", at = @At("TAIL"))
     public void mouseClicked(int x, int y, int button, CallbackInfo ci) {
-        if (button == 0) {
-            if (storeButton.mousePressed(mc, x, y)) {
-                ChestStealer.INSTANCE.setStoring(!ChestStealer.INSTANCE.getStoring());
-            } else if (stealButton.mousePressed(mc, x, y)) {
-                ChestStealer.INSTANCE.setStealing(!ChestStealer.INSTANCE.getStealing());
-            }
+        if (button != 0) return;
+
+        if (storeButton.mousePressed(mc, x, y)) {
+            ChestStealer.INSTANCE.setStoring(!ChestStealer.INSTANCE.getStoring());
+        } else if (stealButton.mousePressed(mc, x, y)) {
+            ChestStealer.INSTANCE.setStealing(!ChestStealer.INSTANCE.getStealing());
         }
     }
 
     @Inject(method = "updateScreen", at = @At("TAIL"))
     public void updateScreen(CallbackInfo ci) {
-        if (ChestStealer.INSTANCE.isValidGui()) {
-            if (ChestStealer.INSTANCE.isEnabled()) {
-                if (!this.buttonList.contains(stealButton)) {
-                    this.buttonList.add(stealButton);
-                }
-                if (!this.buttonList.contains(storeButton)) {
-                    this.buttonList.add(storeButton);
-                }
-                ChestStealer.updateButton(stealButton, this.guiLeft, this.xSize, this.guiTop);
-                ChestStealer.updateButton(storeButton, this.guiLeft, this.xSize, this.guiTop);
-            } else {
-                this.buttonList.remove(storeButton);
-                this.buttonList.remove(storeButton);
-            }
+        if (!ChestStealer.INSTANCE.isValidGui()) return;
+
+        if (!ChestStealer.INSTANCE.isEnabled()) {
+            buttonList.remove(storeButton);
+            buttonList.remove(storeButton);
+            return;
         }
+
+        if (!buttonList.contains(stealButton)) {
+            buttonList.add(stealButton);
+        }
+        if (!buttonList.contains(storeButton)) {
+            buttonList.add(storeButton);
+        }
+
+        ChestStealer.updateButton(stealButton, guiLeft, xSize, guiTop);
+        ChestStealer.updateButton(storeButton, guiLeft, xSize, guiTop);
     }
 
 }

--- a/src/main/java/com/lambda/mixin/gui/MixinGuiContainer.java
+++ b/src/main/java/com/lambda/mixin/gui/MixinGuiContainer.java
@@ -36,7 +36,7 @@ public class MixinGuiContainer extends GuiScreen {
     public void updateScreen(CallbackInfo ci) {
         if (!ChestStealer.INSTANCE.isValidGui()) return;
 
-        if (!ChestStealer.INSTANCE.isEnabled()) {
+        if (ChestStealer.INSTANCE.isDisabled()) {
             buttonList.remove(storeButton);
             buttonList.remove(storeButton);
             return;

--- a/src/main/kotlin/com/lambda/client/module/modules/player/ChestStealer.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/player/ChestStealer.kt
@@ -89,29 +89,21 @@ object ChestStealer : Module(
         runSafe {
             if (isEnabled && isContainerOpen()) {
                 if (button.id == 696969) {
-                    val str = if (stealing) {
-                        "Stop"
-                    } else {
-                        "Steal"
-                    }
+                    val name = if (stealing) "Stop" else "Steal"
 
                     button.x = left + size + 2
                     button.y = top + 2
                     button.enabled = canSteal() and !storing
                     button.visible = true
-                    button.displayString = str
+                    button.displayString = name
                 } else if (button.id == 420420) {
-                    val str = if (storing) {
-                        "Stop"
-                    } else {
-                        "Store"
-                    }
+                    val name = if (storing) "Stop" else "Store"
 
                     button.x = left + size + 2
                     button.y = top + 24
                     button.enabled = canStore() and !stealing
                     button.visible = true
-                    button.displayString = str
+                    button.displayString = name
                 }
             } else {
                 button.visible = false


### PR DESCRIPTION
**Describe the pull**
Rusherhack compatibility...kind of...

Without this, rusherhack will completely break lambda's cheststealer module. 
This change improves that compatibility but does not fix all issues. 

I suspect Rusherhack has some GuiContainer child implementation that causes weird issues with buttons added.

States with both clients present:

- Only Lambda cheststealer on 
  - Steal button is textured and placed where rusherhack's steal is - not ideal,  but it uses lambda's steal function. Normal Lambda Store button present and works.

- Only Rusherhack cheststealer on
  - rusherhack works as normal, both buttons present and work.

- Both rusherhack and lambda cheststealer on 
  - rusherhack buttons both use rusherhack functions. Lambda store button works and uses lambda store function. lambda steal button is not present - not ideal.


**Describe how this pull is helpful**
Rusherhack is a very popular client. If Rusherhack is not present, this module still works exactly as before.

**Additional context**
n/a

