### PR TITLE
Radar: Improve FPS at high zooms

### DIFF
--- a/src/main/kotlin/com/lambda/client/event/events/RenderRadarEvent.kt
+++ b/src/main/kotlin/com/lambda/client/event/events/RenderRadarEvent.kt
@@ -6,5 +6,6 @@ import com.lambda.client.util.graphics.VertexHelper
 class RenderRadarEvent(
     val vertexHelper: VertexHelper,
     val radius: Float,
-    val scale: Float
+    val scale: Float,
+    val chunkLines: Boolean
 ) : Event

--- a/src/main/kotlin/com/lambda/client/gui/hudgui/elements/world/Radar.kt
+++ b/src/main/kotlin/com/lambda/client/gui/hudgui/elements/world/Radar.kt
@@ -28,6 +28,7 @@ internal object Radar : HudElement(
     description = "Shows entities and new chunks"
 ) {
     private val zoom by setting("Zoom", 3f, 1f..10f, 0.1f)
+    private val chunkLines by setting("Chunk Lines", true)
 
     private val players = setting("Players", true)
     private val passive = setting("Passive Mobs", false)
@@ -45,7 +46,7 @@ internal object Radar : HudElement(
 
         runSafe {
             drawBorder(vertexHelper)
-            post(RenderRadarEvent(vertexHelper, radius, zoom)) // Let other modules display radar elements
+            post(RenderRadarEvent(vertexHelper, radius, zoom, chunkLines)) // Let other modules display radar elements
             drawEntities(vertexHelper)
             drawLabels()
         }

--- a/src/main/kotlin/com/lambda/client/module/modules/render/NewChunks.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/render/NewChunks.kt
@@ -122,8 +122,8 @@ object NewChunks : Module(
             val chunkDist = (it.radius * it.scale).toInt() shr 4
             // at high zooms (further zoomed out) there will be thousands of rects being rendered
             // buffering rects here to reduce GL calls and improve FPS
-            val filledChunkRects: MutableList<Pair<Vec2d, Vec2d>> = ArrayList()
-            val outlineChunkRects: MutableList<Pair<Vec2d, Vec2d>> = ArrayList()
+            val distantChunkRects: MutableList<Pair<Vec2d, Vec2d>> = mutableListOf()
+            val chunkGridRects: MutableList<Pair<Vec2d, Vec2d>> = mutableListOf()
             for (chunkX in -chunkDist..chunkDist) {
                 for (chunkZ in -chunkDist..chunkDist) {
                     val pos0 = getChunkPos(chunkX, chunkZ, playerOffset, it.scale)
@@ -137,25 +137,25 @@ object NewChunks : Module(
                             ) ?: false
 
                         if (!chunk.isLoaded && !isCachedChunk) {
-                            filledChunkRects.add(Pair(pos0, pos1))
+                            distantChunkRects.add(Pair(pos0, pos1))
                         }
-                        outlineChunkRects.add(Pair(pos0, pos1))
+                        chunkGridRects.add(Pair(pos0, pos1))
                     }
                 }
             }
-            if (filledChunkRects.isNotEmpty()) RenderUtils2D.drawRectFilledList(it.vertexHelper, filledChunkRects, ColorHolder(100, 100, 100, 100))
-            if (it.chunkLines && outlineChunkRects.isNotEmpty()) RenderUtils2D.drawRectOutlineList(it.vertexHelper, outlineChunkRects, 0.3f, ColorHolder(255, 0, 0, 100))
-            filledChunkRects.clear()
+            if (distantChunkRects.isNotEmpty()) RenderUtils2D.drawRectFilledList(it.vertexHelper, distantChunkRects, distantChunkColor)
+            if (it.chunkLines && chunkGridRects.isNotEmpty()) RenderUtils2D.drawRectOutlineList(it.vertexHelper, chunkGridRects, 0.3f, chunkGridColor)
 
+            val newChunkRects: MutableList<Pair<Vec2d, Vec2d>> = mutableListOf()
             chunks.keys.forEach { chunk ->
                 val pos0 = getChunkPos(chunk.x - player.chunkCoordX, chunk.z - player.chunkCoordZ, playerOffset, it.scale)
                 val pos1 = getChunkPos(chunk.x - player.chunkCoordX + 1, chunk.z - player.chunkCoordZ + 1, playerOffset, it.scale)
 
                 if (isSquareInRadius(pos0, pos1, it.radius)) {
-                    filledChunkRects.add(Pair(pos0, pos1))
+                    newChunkRects.add(Pair(pos0, pos1))
                 }
             }
-            if (filledChunkRects.isNotEmpty()) RenderUtils2D.drawRectFilledList(it.vertexHelper, filledChunkRects, newChunkColor)
+            if (newChunkRects.isNotEmpty()) RenderUtils2D.drawRectFilledList(it.vertexHelper, newChunkRects, newChunkColor)
         }
 
         safeListener<PacketEvent.PostReceive> { event ->

--- a/src/main/kotlin/com/lambda/client/util/graphics/RenderUtils2D.kt
+++ b/src/main/kotlin/com/lambda/client/util/graphics/RenderUtils2D.kt
@@ -87,10 +87,57 @@ object RenderUtils2D {
         drawLineLoop(vertexHelper, vertices, lineWidth, color)
     }
 
+    fun drawRectOutlineList(vertexHelper: VertexHelper,
+                            rects: List<Pair<Vec2d, Vec2d>>,
+                            lineWidth: Float = 1f,
+                            color: ColorHolder) {
+        prepareGl()
+        glLineWidth(lineWidth)
+        vertexHelper.begin(GL_LINES)
+        rects.forEach {
+            val pos1 = it.first // Top left
+            val pos2 = Vec2d(it.second.x, it.first.y) // Top right
+            val pos3 = it.second // Bottom right
+            val pos4 = Vec2d(it.first.x, it.second.y) // Bottom left
+            vertexHelper.put(pos1, color)
+            vertexHelper.put(pos2, color)
+            vertexHelper.put(pos2, color)
+            vertexHelper.put(pos3, color)
+            vertexHelper.put(pos3, color)
+            vertexHelper.put(pos4, color)
+            vertexHelper.put(pos4, color)
+            vertexHelper.put(pos1, color)
+        }
+        vertexHelper.end()
+        releaseGl()
+        glLineWidth(1f)
+    }
+
     fun drawRectFilled(vertexHelper: VertexHelper, posBegin: Vec2d = Vec2d(0.0, 0.0), posEnd: Vec2d, color: ColorHolder) {
         val pos2 = Vec2d(posEnd.x, posBegin.y) // Top right
         val pos4 = Vec2d(posBegin.x, posEnd.y) // Bottom left
         drawQuad(vertexHelper, posBegin, pos2, posEnd, pos4, color)
+    }
+
+    fun drawRectFilledList(vertexHelper: VertexHelper,
+                           rects: List<Pair<Vec2d, Vec2d>>,
+                           color: ColorHolder) {
+        prepareGl()
+        vertexHelper.begin(GL_TRIANGLES)
+        rects.forEach {
+            val pos1 = it.first // Top left
+            val pos2 = Vec2d(it.second.x, it.first.y) // Top right
+            val pos3 = it.second // Bottom right
+            val pos4 = Vec2d(it.first.x, it.second.y) // Bottom left
+            vertexHelper.put(pos1, color)
+            vertexHelper.put(pos2, color)
+            vertexHelper.put(pos4, color)
+            vertexHelper.put(pos4, color)
+            vertexHelper.put(pos3, color)
+            vertexHelper.put(pos2, color)
+        }
+        vertexHelper.end()
+        releaseGl()
     }
 
     private fun drawQuad(vertexHelper: VertexHelper, pos1: Vec2d, pos2: Vec2d, pos3: Vec2d, pos4: Vec2d, color: ColorHolder) {


### PR DESCRIPTION
**Describe the pull**
FPS improvements for NewChunks HUD Radar element, especially when zoomed far out. 

**Describe how this pull is helpful**
Reduces amount of GL render calls to improve FPS. 

On my system, zoom 10:
Before: 30-50 FPS
After: 170 FPS (vsync cap)

Also added an option to disable rendering the chunk border lines. At high zooms these are not helpful visually and further reduce FPS.

**Additional context**
high zooms are very popular with base/stash hunters
