### PR TITLE
Fix incorrect build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ In this guide we will use [IntelliJ IDEA](https://www.jetbrains.com/idea/) as ou
 ### Gradle build
 
 Test if the environment is set up correctly by building the client and running it inside the IDE using the Gradle tab on the right side of the IDE.
-1. Go to `lambda > Tasks > build > runClient` in the Gradle tab and run the client.
+1. Go to `lambda > Tasks > fg_runs > runClient` in the Gradle tab and run the client.
 2. To build the client as a jar run `lambda > Tasks > build > build`. Gradle will create a new directory called `build`. The final built jar will be in `build/libs`.
 
 ### Stargazers


### PR DESCRIPTION
Previously, the runClient task was wrongly under the build folder; now its correctly under the fg_runs folder.