### PR TITLE
EntitySpeed: Add MaxJump setting

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/modules/movement/EntitySpeed.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/EntitySpeed.kt
@@ -24,19 +24,23 @@ object EntitySpeed : Module(
         safeListener<PlayerTravelEvent> {
             player.ridingEntity?.let { entity ->
                 var tamper = false
+
                 val speed = when {
                     entity is AbstractHorse && entity.controllingPassenger == player -> abstractHorseSpeed.also { tamper = true }
                     entity is EntityBoat && entity.controllingPassenger == player -> boatSpeed.also { tamper = true }
                     entity is EntityPig -> pigSpeed.also { tamper = true }
                     else -> .0f
                 }
-                if (tamper) {
-                    steerEntity(entity, speed, antiStuck)
-                    entity.rotationYaw = player.rotationYaw
 
-                    if (maxJump && entity is AbstractHorse && mc.gameSettings.keyBindJump.isKeyDown)
-                        entity.setJumpPower(90)
-                }
+                if (!tamper) return@safeListener
+
+                steerEntity(entity, speed, antiStuck)
+                entity.rotationYaw = player.rotationYaw
+
+                if (maxJump
+                    && entity is AbstractHorse
+                    && mc.gameSettings.keyBindJump.isKeyDown
+                ) entity.setJumpPower(90)
             }
         }
     }

--- a/src/main/kotlin/com/lambda/client/module/modules/movement/EntitySpeed.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/EntitySpeed.kt
@@ -18,6 +18,7 @@ object EntitySpeed : Module(
     private val abstractHorseSpeed by setting("Horse Types Speed", 0.7f, 0.1f..10.0f, 0.05f)
     private val pigSpeed by setting("Pig Speed", 1.0f, 0.1f..10.0f, 0.05f)
     private val antiStuck by setting("Anti Stuck", true)
+    private val maxJump by setting("Max Jump", true)
 
     init {
         safeListener<PlayerTravelEvent> {
@@ -32,6 +33,9 @@ object EntitySpeed : Module(
                 if (tamper) {
                     steerEntity(entity, speed, antiStuck)
                     entity.rotationYaw = player.rotationYaw
+
+                    if (maxJump && entity is AbstractHorse && mc.gameSettings.keyBindJump.isKeyDown)
+                        entity.setJumpPower(90)
                 }
             }
         }


### PR DESCRIPTION
This patch adds the MaxJump setting to the EntitySpeed module. This works by setting the maximum jump value (90) to the entity if its of type AbstractHorse and the user is pressing down the jump key.
