### PR TITLE
Nametags: Add TOTEM_POP_COUNT ContentType

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/modules/combat/TotemPopCounter.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/combat/TotemPopCounter.kt
@@ -35,7 +35,7 @@ object TotemPopCounter : Module(
         CLIENT, EVERYONE
     }
 
-    public val popCountMap = WeakHashMap<EntityPlayer, Int>().synchronized()
+    val popCountMap = WeakHashMap<EntityPlayer, Int>().synchronized()
     private var wasSent = false
 
     init {

--- a/src/main/kotlin/com/lambda/client/module/modules/combat/TotemPopCounter.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/combat/TotemPopCounter.kt
@@ -35,7 +35,7 @@ object TotemPopCounter : Module(
         CLIENT, EVERYONE
     }
 
-    private val popCountMap = WeakHashMap<EntityPlayer, Int>().synchronized()
+    public val popCountMap = WeakHashMap<EntityPlayer, Int>().synchronized()
     private var wasSent = false
 
     init {


### PR DESCRIPTION
This patch allows for the popped totems to be able to be shown in the nametags. The totem pop counting functionality is embedded in the TotemPopCounter module, hence, it needs to be active in order for this to work.

As to ensure this is the case, this patch adds some logic preventing this feature to be enabled when the TotemPopCounter module is inactive, and also re-enables the TotemPopCounter module if this feature is enabled and the user tries to disable the TotemPopCounter module.

EDIT: This is a tiny bit hacky and in the future it could be greatly benefited by a refactor that separates the popped totem counting logic from the TotemPopCounter module, but I believe this works quite OK for now :))