### PR TITLE
Feat(Anti Afk):set start pos

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/modules/misc/AntiAFK.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/misc/AntiAFK.kt
@@ -62,7 +62,6 @@ object AntiAFK : Module(
             if (!allowBreak) BaritoneUtils.settings?.allowBreak?.value = false
             inputTimer.reset()
             baritoneDisconnectOnArrival()
-            }
         }
 
         onDisable {

--- a/src/main/kotlin/com/lambda/client/module/modules/misc/AntiAFK.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/misc/AntiAFK.kt
@@ -31,6 +31,7 @@ object AntiAFK : Module(
     description = "Prevents being kicked while AFK",
     category = Category.MISC
 ) {
+    private val inputTimeout by setting("Idle Timeout", 0, 0..15, 1, description = "Starts AntiAFK after being idle longer than the selected time in minutes, 0 to disable", unit = "m")
     private val delay by setting("Action Delay", 50, 5..100, 5, unit = " ticks")
     private val variation by setting("Variation", 25, 0..50, 5, unit = " ticks")
     private val autoReply by setting("Auto Reply", true)
@@ -39,8 +40,7 @@ object AntiAFK : Module(
     private val jump = setting("Jump", true)
     private val turn = setting("Turn", true)
     private val walk = setting("Walk", true)
-    private val radius by setting("Radius", 64, 8..128, 8, fineStep = 1)
-    private val inputTimeout by setting("Idle Timeout", 0, 0..15, 1, description = "Starts AntiAFK after being idle longer than the selected time in minutes, 0 to disable", unit = "m")
+    private val radius by setting("Radius", 64, 8..128, 8, { walk.value },fineStep = 1)
     private val allowBreak by setting("Allow Breaking Blocks", false, { walk.value })
 
     private var startPos: BlockPos? = null
@@ -62,6 +62,7 @@ object AntiAFK : Module(
             if (!allowBreak) BaritoneUtils.settings?.allowBreak?.value = false
             inputTimer.reset()
             baritoneDisconnectOnArrival()
+            }
         }
 
         onDisable {


### PR DESCRIPTION
**Describe the pull**
I wanted to use anti afk on the 2b2t queue server.
However, because it was fixed based on where it started, the character ran toward the spawn when I used.
So I made it possible to set the fixed point.


**Describe how this pull is helpful**
Now it is possible to set the fixed point when we use anti afk.