### PR TITLE
AutoArmor: Add "Allow Elytra" setting

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/modules/combat/AutoArmor.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/combat/AutoArmor.kt
@@ -23,6 +23,8 @@ object AutoArmor : Module(
     category = Category.COMBAT,
     modulePriority = 500
 ) {
+    private val allowElytra by setting("Allow Elytra", false, description = "If activated it will not replace an equipped elytra with a chestplate")
+
     init {
         safeListener<TickEvent.ClientTickEvent> {
             // store slots and values of best armor pieces, initialize with currently equipped armor
@@ -37,8 +39,8 @@ object AutoArmor : Module(
 
                 val armorType = item.armorType.index
 
-                // Skip if item is chestplate and we have elytra equipped
-                if (armorType == 2 && player.inventory.armorInventory[2].item == Items.ELYTRA) continue
+                // Skip if allowElytra is activated, item is chestplate and we have elytra equipped
+                if (allowElytra && armorType == 2 && player.inventory.armorInventory[2].item == Items.ELYTRA) continue
                 val armorValue = getArmorValue(itemStack)
 
                 if (armorValue > bestArmors[armorType].second) {

--- a/src/main/kotlin/com/lambda/client/module/modules/combat/AutoArmor.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/combat/AutoArmor.kt
@@ -19,7 +19,7 @@ import net.minecraftforge.fml.common.gameevent.TickEvent
 
 object AutoArmor : Module(
     name = "AutoArmor",
-    description = "Automatically equips armour",
+    description = "Automatically equips armor",
     category = Category.COMBAT,
     modulePriority = 500
 ) {
@@ -39,7 +39,7 @@ object AutoArmor : Module(
 
                 val armorType = item.armorType.index
 
-                // Skip if allowElytra is activated, item is chestplate and we have elytra equipped
+                // Skip if allowElytra is activated, item is chestplate, and we have elytra equipped
                 if (allowElytra && armorType == 2 && player.inventory.armorInventory[2].item == Items.ELYTRA) continue
                 val armorValue = getArmorValue(itemStack)
 


### PR DESCRIPTION
This patch introduces the "Allow Elytra" setting in the AutoArmor module, which lets the user chose whether AutoArmor will replace their equipped elytra with a chestplate (allowElytra = false) or not (allowElytra = true) :^)