### PR TITLE
Add ClientSideTime module

### DIFF
--- a/src/main/java/com/lambda/mixin/world/MixinWorld.java
+++ b/src/main/java/com/lambda/mixin/world/MixinWorld.java
@@ -1,7 +1,7 @@
 package com.lambda.mixin.world;
 
 import com.lambda.client.module.modules.misc.AntiWeather;
-import com.lambda.client.module.modules.render.ClientSideTime;
+import com.lambda.client.module.modules.render.TimeWarp;
 import com.lambda.client.module.modules.render.NoRender;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.EnumSkyBlock;
@@ -36,7 +36,7 @@ public class MixinWorld {
 
     @Inject(method = "getWorldTime", at = @At("HEAD"), cancellable = true)
     public void onGetWorldTime(CallbackInfoReturnable<Long> cir) {
-        if (ClientSideTime.INSTANCE.isEnabled())
-            cir.setReturnValue(ClientSideTime.INSTANCE.getUpdatedTime());
+        if (TimeWarp.INSTANCE.isEnabled())
+            cir.setReturnValue(TimeWarp.INSTANCE.getUpdatedTime());
     }
 }

--- a/src/main/java/com/lambda/mixin/world/MixinWorld.java
+++ b/src/main/java/com/lambda/mixin/world/MixinWorld.java
@@ -1,6 +1,7 @@
 package com.lambda.mixin.world;
 
 import com.lambda.client.module.modules.misc.AntiWeather;
+import com.lambda.client.module.modules.render.ClientSideTime;
 import com.lambda.client.module.modules.render.NoRender;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.EnumSkyBlock;
@@ -31,5 +32,11 @@ public class MixinWorld {
         if (AntiWeather.INSTANCE.isEnabled()) {
             cir.setReturnValue(0.0f);
         }
+    }
+
+    @Inject(method = "getWorldTime", at = @At("HEAD"), cancellable = true)
+    public void onGetWorldTime(CallbackInfoReturnable<Long> cir) {
+        if (ClientSideTime.INSTANCE.isEnabled())
+            cir.setReturnValue(ClientSideTime.INSTANCE.getUpdatedTime());
     }
 }

--- a/src/main/kotlin/com/lambda/client/module/modules/render/ClientSideTime.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/render/ClientSideTime.kt
@@ -1,0 +1,35 @@
+package com.lambda.client.module.modules.render
+
+import com.lambda.client.module.Category
+import com.lambda.client.module.Module
+import java.text.SimpleDateFormat
+import java.util.*
+
+object ClientSideTime : Module(
+    name = "ClientSideTime",
+    description = "Change the client-side world time",
+    category = Category.RENDER
+) {
+    private val mode by setting("Mode", ClientSideTimeMode.TICKS)
+    private val time by setting("Time", 0, 0..24000, 600, { mode == ClientSideTimeMode.TICKS })
+
+    enum class ClientSideTimeMode {
+        REAL_WORLD_TIME, TICKS
+    }
+
+    @JvmStatic
+    fun getUpdatedTime(): Long {
+        if (mode == ClientSideTimeMode.REAL_WORLD_TIME)
+            return dateToMinecraftTime(Calendar.getInstance())
+        return time.toLong()
+    }
+
+    private fun dateToMinecraftTime(calendar: Calendar): Long {
+        // We subtract 6 (add 18) to convert the real time to minecraft time :)
+        calendar.add(Calendar.HOUR, 18)
+        val time = calendar.time
+        val minecraftHours = SimpleDateFormat("HH").format(time)
+        val minecraftMinutes = (SimpleDateFormat("mm").format(time).toLong() * 100) / 60
+        return "${minecraftHours}${minecraftMinutes}0".toLong()
+    }
+}

--- a/src/main/kotlin/com/lambda/client/module/modules/render/TimeWarp.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/render/TimeWarp.kt
@@ -2,24 +2,28 @@ package com.lambda.client.module.modules.render
 
 import com.lambda.client.module.Category
 import com.lambda.client.module.Module
+import com.lambda.mixin.world.MixinWorld
 import java.text.SimpleDateFormat
 import java.util.*
 
-object ClientSideTime : Module(
-    name = "ClientSideTime",
+/**
+ * @see MixinWorld.onGetWorldTime
+ */
+object TimeWarp : Module(
+    name = "TimeWarp",
     description = "Change the client-side world time",
     category = Category.RENDER
 ) {
-    private val mode by setting("Mode", ClientSideTimeMode.TICKS)
-    private val time by setting("Time", 0, 0..24000, 600, { mode == ClientSideTimeMode.TICKS })
+    private val mode by setting("Mode", TimeWarpMode.TICKS)
+    private val time by setting("Time", 0, 0..24000, 600, { mode == TimeWarpMode.TICKS })
 
-    enum class ClientSideTimeMode {
+    enum class TimeWarpMode {
         REAL_WORLD_TIME, TICKS
     }
 
     @JvmStatic
     fun getUpdatedTime(): Long {
-        if (mode == ClientSideTimeMode.REAL_WORLD_TIME)
+        if (mode == TimeWarpMode.REAL_WORLD_TIME)
             return dateToMinecraftTime(Calendar.getInstance())
         return time.toLong()
     }


### PR DESCRIPTION
This patch adds the ClientSideTime module, which allows the user to change their client-side world time. It currently has two modes; TICKS and REAL_WORLD_TIME. The former allows you to specify the world time as ticks, and the latter uses your current computer time as the world time.

:)
