### PR TITLE
AbstractSetting: Add "formatter" parameter 

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/modules/misc/AntiDisconnect.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/misc/AntiDisconnect.kt
@@ -8,5 +8,5 @@ object AntiDisconnect : Module(
     description = "Prevents you from accidently disconnecting",
     category = Category.MISC
 ) {
-    val presses by setting("Button Presses", 3, 1..20, 1)
+    val presses by setting("Button Presses", 3, 1..20, 1, formatter = {i -> "$i presses"})
 }

--- a/src/main/kotlin/com/lambda/client/setting/configs/PluginConfig.kt
+++ b/src/main/kotlin/com/lambda/client/setting/configs/PluginConfig.kt
@@ -51,35 +51,35 @@ class PluginConfig(pluginName: String) : NameableConfig<IPluginClass>(
         } ?: emptyList()
     }
 
-    override fun <E : Enum<E>> IPluginClass.setting(name: String, value: E, visibility: () -> Boolean, consumer: (prev: E, input: E) -> E, description: String): EnumSetting<E> {
-        return setting(EnumSetting(name, value, visibility, consumer, description))
+    override fun <E : Enum<E>> IPluginClass.setting(name: String, value: E, visibility: () -> Boolean, consumer: (prev: E, input: E) -> E, description: String, unit: String, formatter: (E) -> String): EnumSetting<E> {
+        return setting(EnumSetting(name, value, visibility, consumer, description, unit, formatter))
     }
 
-    override fun IPluginClass.setting(name: String, value: Boolean, visibility: () -> Boolean, consumer: (prev: Boolean, input: Boolean) -> Boolean, description: String): BooleanSetting {
-        return setting(BooleanSetting(name, value, visibility, consumer, description))
+    override fun IPluginClass.setting(name: String, value: Boolean, visibility: () -> Boolean, consumer: (prev: Boolean, input: Boolean) -> Boolean, description: String, formatter: (Boolean) -> String): BooleanSetting {
+        return setting(BooleanSetting(name, value, visibility, consumer, description, formatter))
     }
 
-    override fun IPluginClass.setting(name: String, value: ColorHolder, hasAlpha: Boolean, visibility: () -> Boolean, description: String): ColorSetting {
-        return setting(ColorSetting(name, value, hasAlpha, visibility, description))
+    override fun IPluginClass.setting(name: String, value: ColorHolder, hasAlpha: Boolean, visibility: () -> Boolean, description: String, formatter: (ColorHolder) -> String): ColorSetting {
+        return setting(ColorSetting(name, value, hasAlpha, visibility, description, formatter))
     }
 
-    override fun IPluginClass.setting(name: String, value: String, visibility: () -> Boolean, consumer: (prev: String, input: String) -> String, description: String): StringSetting {
-        return setting(StringSetting(name, value, visibility, consumer, description))
+    override fun IPluginClass.setting(name: String, value: String, visibility: () -> Boolean, consumer: (prev: String, input: String) -> String, description: String, formatter: (String) -> String): StringSetting {
+        return setting(StringSetting(name, value, visibility, consumer, description, formatter))
     }
 
-    override fun IPluginClass.setting(name: String, value: Double, range: ClosedFloatingPointRange<Double>, step: Double, visibility: () -> Boolean, consumer: (prev: Double, input: Double) -> Double, description: String, unit: String, fineStep: Double): DoubleSetting {
-        return setting(DoubleSetting(name, value, range, step, visibility, consumer, description, unit, fineStep))
+    override fun IPluginClass.setting(name: String, value: Double, range: ClosedFloatingPointRange<Double>, step: Double, visibility: () -> Boolean, consumer: (prev: Double, input: Double) -> Double, description: String, unit: String, fineStep: Double, formatter: (Double) -> String): DoubleSetting {
+        return setting(DoubleSetting(name, value, range, step, visibility, consumer, description, unit, fineStep, formatter))
     }
 
-    override fun IPluginClass.setting(name: String, value: Float, range: ClosedFloatingPointRange<Float>, step: Float, visibility: () -> Boolean, consumer: (prev: Float, input: Float) -> Float, description: String, unit: String, fineStep: Float): FloatSetting {
-        return setting(FloatSetting(name, value, range, step, visibility, consumer, description, unit, fineStep))
+    override fun IPluginClass.setting(name: String, value: Float, range: ClosedFloatingPointRange<Float>, step: Float, visibility: () -> Boolean, consumer: (prev: Float, input: Float) -> Float, description: String, unit: String, fineStep: Float, formatter: (Float) -> String): FloatSetting {
+        return setting(FloatSetting(name, value, range, step, visibility, consumer, description, unit, fineStep, formatter))
     }
 
-    override fun IPluginClass.setting(name: String, value: Int, range: IntRange, step: Int, visibility: () -> Boolean, consumer: (prev: Int, input: Int) -> Int, description: String, unit: String, fineStep: Int): IntegerSetting {
-        return setting(IntegerSetting(name, value, range, step, visibility, consumer, description, unit, fineStep))
+    override fun IPluginClass.setting(name: String, value: Int, range: IntRange, step: Int, visibility: () -> Boolean, consumer: (prev: Int, input: Int) -> Int, description: String, unit: String, fineStep: Int, formatter: (Int) -> String): IntegerSetting {
+        return setting(IntegerSetting(name, value, range, step, visibility, consumer, description, unit, fineStep, formatter))
     }
 
-    override fun IPluginClass.setting(name: String, value: Bind, visibility: () -> Boolean, description: String): BindSetting {
-        return setting(BindSetting(name, value, visibility, description))
+    override fun IPluginClass.setting(name: String, value: Bind, visibility: () -> Boolean, description: String, formatter: (Bind) -> String): BindSetting {
+        return setting(BindSetting(name, value, visibility, description, formatter))
     }
 }

--- a/src/main/kotlin/com/lambda/client/setting/settings/AbstractSetting.kt
+++ b/src/main/kotlin/com/lambda/client/setting/settings/AbstractSetting.kt
@@ -15,6 +15,7 @@ abstract class AbstractSetting<T : Any> : Nameable {
     abstract val visibility: () -> Boolean
     abstract val description: String
     abstract val unit: String
+    abstract val formatter: (T) -> String
 
     val listeners = ArrayList<() -> Unit>()
     val valueListeners = ArrayList<(prev: T, input: T) -> Unit>()
@@ -34,7 +35,7 @@ abstract class AbstractSetting<T : Any> : Nameable {
     abstract fun write(): JsonElement
     abstract fun read(jsonElement: JsonElement?)
 
-    override fun toString() = "$value$unit"
+    override fun toString() = "${formatter(value)}$unit"
 
     override fun equals(other: Any?) = this === other
         || (other is AbstractSetting<*>

--- a/src/main/kotlin/com/lambda/client/setting/settings/ImmutableSetting.kt
+++ b/src/main/kotlin/com/lambda/client/setting/settings/ImmutableSetting.kt
@@ -15,6 +15,7 @@ abstract class ImmutableSetting<T : Any>(
     override val visibility: () -> Boolean,
     val consumer: (prev: T, input: T) -> T,
     override val description: String,
+    override val formatter: (T) -> String,
     override val unit: String
 ) : AbstractSetting<T>() {
     override val value: T = valueIn

--- a/src/main/kotlin/com/lambda/client/setting/settings/MutableSetting.kt
+++ b/src/main/kotlin/com/lambda/client/setting/settings/MutableSetting.kt
@@ -18,6 +18,7 @@ open class MutableSetting<T : Any>(
     override val visibility: () -> Boolean,
     consumer: (prev: T, input: T) -> T,
     override val description: String,
+    override val formatter: (T) -> String,
     override val unit: String
 ) : AbstractSetting<T>() {
 

--- a/src/main/kotlin/com/lambda/client/setting/settings/SettingRegister.kt
+++ b/src/main/kotlin/com/lambda/client/setting/settings/SettingRegister.kt
@@ -30,7 +30,8 @@ interface SettingRegister<T : Any> {
         description: String = "",
         unit: String = "",
         fineStep: Int = step,
-    ) = setting(IntegerSetting(name, value, range, step, visibility, consumer, description, unit, fineStep))
+        formatter: (Int) -> String = { i -> "$i"},
+        ) = setting(IntegerSetting(name, value, range, step, visibility, consumer, description, unit, fineStep, formatter))
 
     /** Double Setting */
     fun T.setting(
@@ -43,7 +44,8 @@ interface SettingRegister<T : Any> {
         description: String = "",
         unit: String = "",
         fineStep: Double = step,
-    ) = setting(DoubleSetting(name, value, range, step, visibility, consumer, description, unit, fineStep))
+        formatter: (Double) -> String = { d -> "$d"},
+        ) = setting(DoubleSetting(name, value, range, step, visibility, consumer, description, unit, fineStep, formatter))
 
     /** Float Setting */
     fun T.setting(
@@ -56,15 +58,17 @@ interface SettingRegister<T : Any> {
         description: String = "",
         unit: String = "",
         fineStep: Float = step,
-    ) = setting(FloatSetting(name, value, range, step, visibility, consumer, description, unit, fineStep))
+        formatter: (Float) -> String = { f -> "$f"},
+        ) = setting(FloatSetting(name, value, range, step, visibility, consumer, description, unit, fineStep, formatter))
 
     /** Bind Setting */
     fun T.setting(
         name: String,
         value: Bind,
         visibility: () -> Boolean = { true },
-        description: String = ""
-    ) = setting(BindSetting(name, value, visibility, description))
+        description: String = "",
+        formatter: (Bind) -> String = { b -> "$b"},
+        ) = setting(BindSetting(name, value, visibility, description, formatter))
 
     /** Color Setting */
     fun T.setting(
@@ -72,8 +76,9 @@ interface SettingRegister<T : Any> {
         value: ColorHolder,
         hasAlpha: Boolean = true,
         visibility: () -> Boolean = { true },
-        description: String = ""
-    ) = setting(ColorSetting(name, value, hasAlpha, visibility, description))
+        description: String = "",
+        formatter: (ColorHolder) -> String = { c -> "$c"},
+        ) = setting(ColorSetting(name, value, hasAlpha, visibility, description, formatter))
 
     /** Boolean Setting */
     fun T.setting(
@@ -81,8 +86,9 @@ interface SettingRegister<T : Any> {
         value: Boolean,
         visibility: () -> Boolean = { true },
         consumer: (prev: Boolean, input: Boolean) -> Boolean = { _, input -> input },
-        description: String = ""
-    ) = setting(BooleanSetting(name, value, visibility, consumer, description))
+        description: String = "",
+        formatter: (Boolean) -> String = { b -> "$b"},
+        ) = setting(BooleanSetting(name, value, visibility, consumer, description, formatter))
 
     /** Enum Setting */
     fun <E : Enum<E>> T.setting(
@@ -90,8 +96,10 @@ interface SettingRegister<T : Any> {
         value: E,
         visibility: () -> Boolean = { true },
         consumer: (prev: E, input: E) -> E = { _, input -> input },
-        description: String = ""
-    ) = setting(EnumSetting(name, value, visibility, consumer, description))
+        description: String = "",
+        unit: String = "",
+        formatter: (E) -> String = { e -> "$e"},
+        ) = setting(EnumSetting(name, value, visibility, consumer, description, unit, formatter))
 
     /** String Setting */
     fun T.setting(
@@ -99,8 +107,9 @@ interface SettingRegister<T : Any> {
         value: String,
         visibility: () -> Boolean = { true },
         consumer: (prev: String, input: String) -> String = { _, input -> input },
-        description: String = ""
-    ) = setting(StringSetting(name, value, visibility, consumer, description))
+        description: String = "",
+        formatter: (String) -> String = { s -> s },
+        ) = setting(StringSetting(name, value, visibility, consumer, description, formatter))
     /* End of setting registering */
 
     fun <T : Any> AbstractSetting<T>.atValue(page: T): () -> Boolean = {

--- a/src/main/kotlin/com/lambda/client/setting/settings/impl/collection/CollectionSetting.kt
+++ b/src/main/kotlin/com/lambda/client/setting/settings/impl/collection/CollectionSetting.kt
@@ -3,14 +3,16 @@ package com.lambda.client.setting.settings.impl.collection
 import com.google.gson.JsonElement
 import com.google.gson.reflect.TypeToken
 import com.lambda.client.setting.settings.ImmutableSetting
+import com.lambda.client.util.color.ColorHolder
 
 class CollectionSetting<E : Any, T : MutableCollection<E>>(
     name: String,
     override val value: T,
     visibility: () -> Boolean = { true },
     description: String = "",
-    unit: String = ""
-) : ImmutableSetting<T>(name, value, visibility, { _, input -> input }, description, unit), MutableCollection<E> by value {
+    unit: String = "",
+    formatter: (T) -> String = { c -> "$c"},
+    ) : ImmutableSetting<T>(name, value, visibility, { _, input -> input }, description, formatter, unit), MutableCollection<E> by value {
 
     override val defaultValue: T = valueClass.newInstance()
     private val lockObject = Any()

--- a/src/main/kotlin/com/lambda/client/setting/settings/impl/collection/MapSetting.kt
+++ b/src/main/kotlin/com/lambda/client/setting/settings/impl/collection/MapSetting.kt
@@ -9,8 +9,9 @@ class MapSetting<K : Any, V : Any, T : MutableMap<K, V>>(
     override val value: T,
     visibility: () -> Boolean = { true },
     description: String = "",
-    unit: String = ""
-) : ImmutableSetting<T>(name, value, visibility, { _, input -> input }, description, unit) {
+    unit: String = "",
+    formatter: (T) -> String = {m -> "$m"},
+    ) : ImmutableSetting<T>(name, value, visibility, { _, input -> input }, description, formatter, unit) {
     override val defaultValue: T = valueClass.newInstance()
     private val type = object : TypeToken<Map<K, V>>() {}.type
 

--- a/src/main/kotlin/com/lambda/client/setting/settings/impl/number/DoubleSetting.kt
+++ b/src/main/kotlin/com/lambda/client/setting/settings/impl/number/DoubleSetting.kt
@@ -11,8 +11,9 @@ class DoubleSetting(
     consumer: (prev: Double, input: Double) -> Double = { _, input -> input },
     description: String = "",
     unit: String = "",
-    fineStep: Double = step
-) : NumberSetting<Double>(name, value, range, step, visibility, consumer, description, unit, fineStep) {
+    fineStep: Double = step,
+    formatter: (Double) -> String = { d -> "$d"},
+    ) : NumberSetting<Double>(name, value, range, step, visibility, consumer, description, formatter, unit, fineStep) {
 
     init {
         consumers.add(0) { _, it ->

--- a/src/main/kotlin/com/lambda/client/setting/settings/impl/number/FloatSetting.kt
+++ b/src/main/kotlin/com/lambda/client/setting/settings/impl/number/FloatSetting.kt
@@ -11,8 +11,9 @@ class FloatSetting(
     consumer: (prev: Float, input: Float) -> Float = { _, input -> input },
     description: String = "",
     unit: String = "",
-    fineStep: Float = step
-) : NumberSetting<Float>(name, value, range, step, visibility, consumer, description, unit, fineStep) {
+    fineStep: Float = step,
+    formatter: (Float) -> String = { f -> "$f"},
+    ) : NumberSetting<Float>(name, value, range, step, visibility, consumer, description, formatter, unit, fineStep) {
 
     init {
         consumers.add(0) { _, it ->

--- a/src/main/kotlin/com/lambda/client/setting/settings/impl/number/IntegerSetting.kt
+++ b/src/main/kotlin/com/lambda/client/setting/settings/impl/number/IntegerSetting.kt
@@ -11,8 +11,9 @@ class IntegerSetting(
     consumer: (prev: Int, input: Int) -> Int = { _, input -> input },
     description: String = "",
     unit: String = "",
-    fineStep: Int = step
-) : NumberSetting<Int>(name, value, range, step, visibility, consumer, description, unit, fineStep) {
+    fineStep: Int = step,
+    formatter: (Int) -> String = { i -> "$i"},
+    ) : NumberSetting<Int>(name, value, range, step, visibility, consumer, description, formatter, unit, fineStep) {
 
     init {
         consumers.add(0) { _, it ->

--- a/src/main/kotlin/com/lambda/client/setting/settings/impl/number/NumberSetting.kt
+++ b/src/main/kotlin/com/lambda/client/setting/settings/impl/number/NumberSetting.kt
@@ -11,9 +11,10 @@ abstract class NumberSetting<T>(
     visibility: () -> Boolean,
     consumer: (prev: T, input: T) -> T,
     description: String = "",
+    formatter: (T) -> String,
     unit: String = "",
     val fineStep: T
-) : MutableSetting<T>(name, value, visibility, consumer, description, unit)
+) : MutableSetting<T>(name, value, visibility, consumer, description, formatter, unit)
     where T : Number, T : Comparable<T> {
 
     override fun write() = JsonPrimitive(value)

--- a/src/main/kotlin/com/lambda/client/setting/settings/impl/other/BindSetting.kt
+++ b/src/main/kotlin/com/lambda/client/setting/settings/impl/other/BindSetting.kt
@@ -11,8 +11,9 @@ class BindSetting(
     name: String,
     value: Bind,
     visibility: () -> Boolean = { true },
-    description: String = ""
-) : ImmutableSetting<Bind>(name, value, visibility, { _, input -> input }, description, unit = "") {
+    description: String = "",
+    formatter: (Bind) -> String = { b -> "$b"},
+    ) : ImmutableSetting<Bind>(name, value, visibility, { _, input -> input }, description, formatter, unit = "") {
 
     override val defaultValue: Bind = Bind(TreeSet(value.modifierKeys), value.key, null)
 

--- a/src/main/kotlin/com/lambda/client/setting/settings/impl/other/ColorSetting.kt
+++ b/src/main/kotlin/com/lambda/client/setting/settings/impl/other/ColorSetting.kt
@@ -8,5 +8,6 @@ class ColorSetting(
     value: ColorHolder,
     val hasAlpha: Boolean = true,
     visibility: () -> Boolean = { true },
-    description: String = ""
-) : MutableSetting<ColorHolder>(name, value, visibility, { _, input -> if (!hasAlpha) input.apply { a = 255 } else input }, description, unit = "")
+    description: String = "",
+    formatter: (ColorHolder) -> String = { c -> "$c"},
+    ) : MutableSetting<ColorHolder>(name, value, visibility, { _, input -> if (!hasAlpha) input.apply { a = 255 } else input }, description, formatter, unit = "")

--- a/src/main/kotlin/com/lambda/client/setting/settings/impl/primitive/BooleanSetting.kt
+++ b/src/main/kotlin/com/lambda/client/setting/settings/impl/primitive/BooleanSetting.kt
@@ -9,8 +9,9 @@ open class BooleanSetting(
     value: Boolean,
     visibility: () -> Boolean = { true },
     consumer: (prev: Boolean, input: Boolean) -> Boolean = { _, input -> input },
-    description: String = ""
-) : MutableSetting<Boolean>(name, value, visibility, consumer, description, unit = "") {
+    description: String = "",
+    formatter: (Boolean) -> String = { b -> "$b"},
+    ) : MutableSetting<Boolean>(name, value, visibility, consumer, description, formatter, unit = "") {
 
     override fun write(): JsonElement = JsonPrimitive(value)
 

--- a/src/main/kotlin/com/lambda/client/setting/settings/impl/primitive/EnumSetting.kt
+++ b/src/main/kotlin/com/lambda/client/setting/settings/impl/primitive/EnumSetting.kt
@@ -11,8 +11,9 @@ class EnumSetting<T : Enum<T>>(
     visibility: () -> Boolean = { true },
     consumer: (prev: T, input: T) -> T = { _, input -> input },
     description: String = "",
-    unit: String = ""
-) : MutableSetting<T>(name, value, visibility, consumer, description, unit) {
+    unit: String = "",
+    formatter: (T) -> String = { e -> "$e"},
+    ) : MutableSetting<T>(name, value, visibility, consumer, description, formatter, unit) {
 
     private val enumClass: Class<T> = value.declaringJavaClass
     val enumValues: Array<out T> = enumClass.enumConstants

--- a/src/main/kotlin/com/lambda/client/setting/settings/impl/primitive/StringSetting.kt
+++ b/src/main/kotlin/com/lambda/client/setting/settings/impl/primitive/StringSetting.kt
@@ -9,8 +9,9 @@ class StringSetting(
     value: String,
     visibility: () -> Boolean = { true },
     consumer: (prev: String, input: String) -> String = { _, input -> input },
-    description: String = ""
-) : MutableSetting<String>(name, value, visibility, consumer, description, unit = "") {
+    description: String = "",
+    formatter: (String) -> String = { s -> s },
+    ) : MutableSetting<String>(name, value, visibility, consumer, description, formatter, unit = "") {
 
     override fun setValue(valueIn: String) {
         value = valueIn


### PR DESCRIPTION
This patch adds a new "formatter: (T) -> String" parameter to the
AbstractSetting abstract class. This allows for formatter functions to
be passed to settings for them to display their value in a more user
friendly way :)

A possible usage of this would be to replace the unit parameter, as it
simply concatenates the unit string to the setting value, which is a bit
misleading IMO.

P.S. This PR also includes an actual usage of this new parameter in the AntiDisconnect module 