### PR TITLE
Fix incorrect Gradle task path

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ In this guide we will use [IntelliJ IDEA](https://www.jetbrains.com/idea/) as ou
 ### Gradle build
 
 Test if the environment is set up correctly by building the client and running it inside the IDE using the Gradle tab on the right side of the IDE.
-1. Go to `lambda > Tasks > build > runClient` in the Gradle tab and run the client.
+1. Go to `lambda > Tasks > forgegradle runs > runClient` in the Gradle tab and run the client.
 2. To build the client as a jar run `lambda > Tasks > build > build`. Gradle will create a new directory called `build`. The final built jar will be in `build/libs`.
 
 ### Stargazers


### PR DESCRIPTION
**Describe the pull**
Update Gradle task path for running client

**Describe how this pull is helpful**
Correct path avoids confusion

**Additional context**
![image](https://user-images.githubusercontent.com/50793769/216129419-21a5d293-4671-4068-b29e-56521c649f82.png)

