### PR TITLE
SafeWalk + Step Compatibility

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/modules/movement/SafeWalk.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/SafeWalk.kt
@@ -32,7 +32,7 @@ object SafeWalk : Module(
                 var x = event.x
                 var z = event.z
 
-                var boundingBox = player.entityBoundingBox.offset(0.0, (-player.stepHeight).toDouble(), 0.0)
+                var boundingBox = player.entityBoundingBox.offset(0.0, -.6, 0.0)
 
                 while (x != 0.0 && world.getCollisionBoxes(player, boundingBox.offset(x, 0.0, 0.0)).isEmpty()) {
                     x = updateCoordinate(x)


### PR DESCRIPTION
**Describe the pull**
Step modifies player.stepHeight which messes up safewalk calculations when both are enabled

**Describe how this pull is helpful**
Fixes expected functionality

**Additional context**
0.6 is the default player stepHeight. This should never change so its fine to hardcode this value here
