### PR TITLE
FreeLook Module

### DIFF
--- a/src/main/java/com/lambda/mixin/entity/MixinEntity.java
+++ b/src/main/java/com/lambda/mixin/entity/MixinEntity.java
@@ -4,6 +4,7 @@ import com.lambda.client.module.modules.movement.Step;
 import com.lambda.client.module.modules.movement.Velocity;
 import com.lambda.client.module.modules.player.Freecam;
 import com.lambda.client.module.modules.player.ViewLock;
+import com.lambda.client.module.modules.render.FreeLook;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.entity.Entity;
@@ -33,6 +34,7 @@ public abstract class MixinEntity {
     public void turn(float yaw, float pitch, CallbackInfo ci) {
         Entity casted = (Entity) (Object) this;
 
+        if (FreeLook.handleTurn(casted, yaw, pitch, ci)) return;
         if (Freecam.handleTurn(casted, yaw, pitch, ci)) return;
         ViewLock.handleTurn(casted, yaw, pitch, ci);
     }

--- a/src/main/kotlin/com/lambda/client/event/ForgeEventProcessor.kt
+++ b/src/main/kotlin/com/lambda/client/event/ForgeEventProcessor.kt
@@ -165,4 +165,9 @@ internal object ForgeEventProcessor {
     fun onRenderFogColors(event: EntityViewRenderEvent.FogColors) {
         LambdaEventBus.post(event)
     }
+
+    @SubscribeEvent
+    fun onCameraSetupEvent(event: EntityViewRenderEvent.CameraSetup) {
+        LambdaEventBus.post(event)
+    }
 }

--- a/src/main/kotlin/com/lambda/client/module/modules/render/FreeLook.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/render/FreeLook.kt
@@ -1,0 +1,80 @@
+package com.lambda.client.module.modules.render
+
+import com.lambda.client.event.SafeClientEvent
+import com.lambda.client.module.Category
+import com.lambda.client.module.Module
+import com.lambda.client.util.threads.safeListener
+import net.minecraft.entity.Entity
+import net.minecraft.util.math.MathHelper
+import net.minecraftforge.client.event.EntityViewRenderEvent
+import net.minecraftforge.client.event.InputUpdateEvent
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo
+
+object FreeLook : Module(
+    name = "FreeLook",
+    description = "Look Freely",
+    category = Category.RENDER
+) {
+    private val arrowKeyYawAdjust by setting("Arrow Key Yaw Adjust", false)
+    private val arrowKeyYawAdjustIncrement by setting("Yaw Adjust Increment", 1.0f, 0.001f..10.0f, 0.001f,
+        visibility = { arrowKeyYawAdjust });
+
+    private var cameraYaw: Float = 0f
+    private var cameraPitch: Float = 0f
+    private var thirdPersonBefore: Int = 0
+
+    init {
+        onEnable {
+            thirdPersonBefore = mc.gameSettings.thirdPersonView
+            mc.gameSettings.thirdPersonView = 1;
+            cameraYaw = mc.player.rotationYaw + 180.0f
+            cameraPitch = mc.player.rotationPitch
+        }
+
+        onDisable {
+            mc.gameSettings.thirdPersonView = thirdPersonBefore
+        }
+
+        safeListener<EntityViewRenderEvent.CameraSetup> {
+            if (mc.gameSettings.thirdPersonView > 0) {
+                it.yaw = cameraYaw
+                it.pitch = cameraPitch
+            }
+        }
+
+        safeListener<InputUpdateEvent> {
+            if (arrowKeyYawAdjust) {
+                if (it.movementInput.leftKeyDown) {
+                    // shift cam and player rot left by x degrees
+                    updateYaw(-arrowKeyYawAdjustIncrement)
+                    it.movementInput.leftKeyDown = false
+                }
+                if (it.movementInput.rightKeyDown) {
+                    // shift cam and player rot right by x degrees
+                    updateYaw(arrowKeyYawAdjustIncrement)
+                    it.movementInput.rightKeyDown = false
+                }
+                it.movementInput.moveStrafe = 0.0f
+            }
+        }
+    }
+
+    private fun SafeClientEvent.updateYaw(dYaw: Float) {
+        cameraYaw += dYaw
+        player.rotationYaw += dYaw
+    }
+
+    @JvmStatic
+    fun handleTurn(entity: Entity, yaw: Float, pitch: Float, ci: CallbackInfo): Boolean {
+        if (isDisabled || mc.player == null) return false
+        return if (entity == mc.player) {
+            this.cameraYaw += yaw * 0.15f
+            this.cameraPitch -= pitch * 0.15f
+            this.cameraPitch = MathHelper.clamp(this.cameraPitch, -180.0f, 180.0f)
+            ci.cancel()
+            true
+        } else {
+            false
+        }
+    }
+}


### PR DESCRIPTION
**Describe the pull**
Allows you to rotate the camera without rotating the player. 

**Describe how this pull is helpful**
Often useful while traveling or doing some automatic action where you don't want to input a different rotation.
