### PR TITLE
Fixed scuffed window scrolling animation

### DIFF
--- a/src/main/kotlin/com/lambda/client/gui/rgui/windows/ListWindow.kt
+++ b/src/main/kotlin/com/lambda/client/gui/rgui/windows/ListWindow.kt
@@ -131,13 +131,16 @@ open class ListWindow(
         val maxScrollProgress = lastVisible?.let { max(it.posY + it.height + ClickGUI.verticalMargin + ClickGUI.resizeBar - height, 0.01f) }
             ?: draggableHeight
 
-        scrollProgress = (scrollProgress + scrollSpeed)
-        scrollSpeed *= 0.5f
+        var newProgress = scrollProgress + scrollSpeed
 
         if (!ClickGUI.scrollRubberband) {
-            scrollProgress = scrollProgress.coerceIn(.0f, maxScrollProgress)
-            prevScrollProgress = prevScrollProgress.coerceIn(.0f, maxScrollProgress)
-        } else if (scrollTimer.tick(100L, false)) {
+            newProgress = newProgress.coerceIn(0.0f, maxScrollProgress)
+        }
+
+        scrollProgress = newProgress
+        scrollSpeed *= 0.5f
+
+        if (scrollTimer.tick(100L, false)) {
             if (scrollProgress < 0) {
                 scrollSpeed = scrollProgress * -ClickGUI.scrollRubberbandSpeed
             } else if (scrollProgress > maxScrollProgress) {


### PR DESCRIPTION
The "fix" was done horribly wrong and this should fix the scuffed animation when "Scroll Rubberband" is disabled.