### PR TITLE
Update Baritone to 1.2.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,10 +109,10 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:23.0.0'
 
     // This Baritone will NOT be included in the jar
-    implementation 'cabaletta:baritone-deobf-unoptimized-mcp-dev:1.2'
+    implementation('cabaletta:baritone-deobf-unoptimized-mcp-dev:1.2').setChanging(true)
 
     // This Baritone WILL be included in the jar
-    jarLibs 'cabaletta:baritone-api:1.2'
+    jarLibs('cabaletta:baritone-api:1.2').setChanging(true)
 
     // Add everything in jarLibs to implementation (compile)
     implementation configurations.jarLibs

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ minecraft {
 
 configurations {
     jarLibs
+    onlyJarLibs
     // Force choosing the correct nightly build because Mac OS chooses an invalid one
     all {
         resolutionStrategy {
@@ -109,10 +110,10 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:23.0.0'
 
     // This Baritone will NOT be included in the jar
-    implementation 'com.github.cabaletta:baritone:1.2.14'
+    implementation "com.github.rfresh2.baritone:baritone-deobf:d0ce0d1678"
 
     // This Baritone WILL be included in the jar
-    jarLibs 'cabaletta:baritone-api:1.2'
+    onlyJarLibs 'com.github.cabaletta.baritone:baritone-api:v1.2.17'
 
     // Add everything in jarLibs to implementation (compile)
     implementation configurations.jarLibs
@@ -184,7 +185,7 @@ shadowJar {
             'kotlin/**/*.kotlin_metadata',
             'kotlin/**/*.kotlin_builtins',
             'META-INF/*.version'
-    configurations = [project.configurations.jarLibs]
+    configurations = [project.configurations.jarLibs, project.configurations.onlyJarLibs]
     relocate 'kotlin', 'com.lambda.shadow.kotlin'
     relocate 'kotlinx', 'com.lambda.shadow.kotlinx'
     finalizedBy 'configureReobfTaskForReobfShadowJar', 'reobfShadowJar'

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,6 @@ minecraft {
 
 configurations {
     jarLibs
-    onlyJarLibs
     // Force choosing the correct nightly build because Mac OS chooses an invalid one
     all {
         resolutionStrategy {
@@ -110,10 +109,10 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:23.0.0'
 
     // This Baritone will NOT be included in the jar
-    implementation "com.github.rfresh2.baritone:baritone-deobf:d0ce0d1678"
+    implementation 'cabaletta:baritone-deobf-unoptimized-mcp-dev:1.2'
 
     // This Baritone WILL be included in the jar
-    onlyJarLibs 'com.github.cabaletta.baritone:baritone-api:v1.2.17'
+    jarLibs 'cabaletta:baritone-api:1.2'
 
     // Add everything in jarLibs to implementation (compile)
     implementation configurations.jarLibs
@@ -185,7 +184,7 @@ shadowJar {
             'kotlin/**/*.kotlin_metadata',
             'kotlin/**/*.kotlin_builtins',
             'META-INF/*.version'
-    configurations = [project.configurations.jarLibs, project.configurations.onlyJarLibs]
+    configurations = [project.configurations.jarLibs]
     relocate 'kotlin', 'com.lambda.shadow.kotlin'
     relocate 'kotlinx', 'com.lambda.shadow.kotlinx'
     finalizedBy 'configureReobfTaskForReobfShadowJar', 'reobfShadowJar'

--- a/src/main/kotlin/com/lambda/client/module/modules/client/Baritone.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/client/Baritone.kt
@@ -34,8 +34,6 @@ object Baritone : Module(
     private val allowDownwardTunneling by setting("Downward Tunneling", true, { page == Page.BASIC }, description = "Allow mining blocks directly beneath you.")
     private val allowParkour by setting("Allow Parkour", true, { page == Page.BASIC })
     private val allowParkourPlace by setting("Allow Parkour Place", true, { allowParkour && page == Page.BASIC })
-    private val buildInLayers by setting("Build In Layers", false, { page == Page.BASIC }, description = "Build/mine one layer at a time in schematics and selections.")
-    private val layerOrder by setting("Top To Bottom", false, { buildInLayers && page == Page.BASIC }, description = "Build/mine from top to bottom in schematics and selections.")
 
     /* Visual */
     private val freeLook by setting("Free Look", true, { page == Page.VISUAL }, description = "Move without having to force the client-sided rotations.")
@@ -50,6 +48,22 @@ object Baritone : Module(
     private val allowWaterBucketFall by setting("Water Bucket Clutch", true, { page == Page.FALL }, description = "Uses a water bucket to get down quickly.")
     private val maxFallHeightBucket by setting("Max Bucket Height", 20, 10..250, 10, { allowWaterBucketFall && page == Page.FALL }, description = "Max height that baritone can use a water bucket.")
 
+    /* Build */
+    private val buildInLayers by setting("Build In Layers", false, { page == Page.BUILD }, description = "Build/mine one layer at a time in schematics and selections.")
+    private val layerOrder by setting("Top To Bottom", false, { buildInLayers && page == Page.BUILD }, description = "Build/mine from top to bottom in schematics and selections.")
+    private val startAtLayer by setting("Start At Layer", 0, 0..256, 1, visibility = { buildInLayers && page == Page.BUILD }, description = "Start building the schematic at a specific layer.")
+    private val layerHeight by setting("Layer Height", 1, 1..50, 1, visibility = { buildInLayers && page == Page.BUILD }, description = "How high should the individual layers be?")
+    private val skipFailedLayers by setting("Skip Failed Layers", false, { buildInLayers && page == Page.BUILD }, description = "If a layer is unable to be constructed, just skip it.")
+    private val buildOnlySelection by setting("Build Only Selection", false, { page == Page.BUILD }, description = "Only build the selected part of schematics")
+    private val buildIgnoreExisting by setting("Build Ignore Existing", false, { page == Page.BUILD }, description = "If this is true, the builder will treat all non-air blocks as correct. It will only place new blocks.")
+    private val buildIgnoreDirection by setting("Build Ignore Direction", false, { page == Page.BUILD }, description = "If this is true, the builder will ignore directionality of certain blocks like glazed terracotta.")
+    private val mapArtMode by setting("Map Art Mode", false, { page == Page.BUILD }, description = "Build in map art mode, which makes baritone only care about the top block in each column")
+    private val schematicOrientationX by setting("Schematic Orientation X", false, { page == Page.BUILD }, description = "When this setting is true, build a schematic with the highest X coordinate being the origin, instead of the lowest")
+    private val schematicOrientationY by setting("Schematic Orientation Y", false, { page == Page.BUILD }, description = "When this setting is true, build a schematic with the highest Y coordinate being the origin, instead of the lowest")
+    private val schematicOrientationZ by setting("Schematic Orientation Z", false, { page == Page.BUILD }, description = "When this setting is true, build a schematic with the highest Z coordinate being the origin, instead of the lowest")
+    private val okIfWater by setting("Ok If Water", false, { page == Page.BUILD }, description = "Override builder's behavior to not attempt to correct blocks that are currently water")
+    private val incorrectSize by setting("Incorrect Size", 100, 1..1000, 1, { page == Page.BUILD }, description = "The set of incorrect blocks can never grow beyond this size")
+
     /* Advanced */
     private val blockReachDistance by setting("Reach Distance", 4.5f, 1.0f..10.0f, 0.5f, { page == Page.ADVANCED }, description = "Max distance baritone can place blocks.")
     private val enterPortals by setting("Enter Portals", true, { page == Page.ADVANCED }, description = "Baritone will walk all the way into the portal, instead of stopping one block before.")
@@ -62,9 +76,19 @@ object Baritone : Module(
     private val mobAvoidanceCoefficient by setting("Mob Avoidance Coefficient", 1.5f, 0f..5f, 0.5f, visibility = { avoidance && page == Page.ADVANCED }, description = "Set to 1.0 to effectively disable this feature. Set below 1.0 to go out of your way to walk near mobs.")
     private val mobSpawnerAvoidanceRadius by setting("Mob Spawner Avoidance Radius", 10, 0..60, 10, visibility = { avoidance && page == Page.ADVANCED }, description = "Distance to avoid mob spawners.")
     private val mobSpawnerAvoidanceCoefficient by setting("Mob Spawner Avoidance Coefficient", 1.5f, 0f..5f, 0.5f, visibility = { avoidance && page == Page.ADVANCED }, description = "Set to 1.0 to effectively disable this feature. Set below 1.0 to go out of your way to walk near mob spawners.")
+    private val preferSilkTouch by setting("Prefer Silk Touch", false, { page == Page.ADVANCED }, description = "Always prefer silk touch tools over regular tools.")
+    private val backfill by setting("Backfill", false, { page == Page.ADVANCED }, description = "Fill in blocks behind you")
+    private val chunkCaching by setting("Chunk Caching", true, { page == Page.ADVANCED }, description = "Download all chunks in simplified 2-bit format and save them for better very-long-distance pathing.")
+    private val assumeStep by setting("Assume Step", false, { page == Page.ADVANCED }, description = "Assume step functionality; don't jump on an Ascend.")
+    private val assumeExternalAutoTool by setting("Assume External AutoTool", false, { page == Page.ADVANCED }, description = "Disable baritone's auto-tool at runtime, but still assume that another mod will provide auto tool functionality")
+    private val autoTool by setting("AutoTool", true, { page == Page.ADVANCED }, description = "Automatically select the best available tool")
+    private val assumeSafeWalk by setting("Assume Safe Walk", false, { page == Page.ADVANCED }, description = "Assume safe walk functionality; don't sneak on a backplace traverse.")
+    private val allowJumpAt256 by setting("Allow Jump At 256", false, { page == Page.ADVANCED }, description = "If true, parkour is allowed to make jumps when standing on blocks at the maximum height, so player feet is y=256")
+    private val allowDiagonalDescend by setting("Allow Diagonal Descend", false, { page == Page.ADVANCED }, description = "Allow descending diagonally. Safer than allowParkour yet still slightly unsafe, can make contact with unchecked adjacent blocks, so it's unsafe in the nether.")
+    private val allowDiagonalAscend by setting("Allow Diagonal Ascend", false, { page == Page.ADVANCED }, description = "Allow diagonal ascending. Actually pretty safe, much safer than diagonal descend tbh")
 
     private enum class Page {
-        BASIC, VISUAL, FALL, ADVANCED
+        BASIC, VISUAL, FALL, BUILD, ADVANCED
     }
 
     init {
@@ -105,14 +129,12 @@ object Baritone : Module(
             it.chatControl.value = false // enable chatControlAnyway if you want to use it
             /* Basic */
             it.allowBreak.value = allowBreak
-            it.allowPlace.value = allowPlace
             it.allowSprint.value = allowSprint
+            it.allowPlace.value = allowPlace
             it.allowInventory.value = allowInventory
             it.allowDownward.value = allowDownwardTunneling
             it.allowParkour.value = allowParkour
             it.allowParkourPlace.value = allowParkourPlace
-            it.buildInLayers.value = buildInLayers
-            it.layerOrder.value = layerOrder
             /* Visual */
             it.freeLook.value = freeLook
             it.renderGoal.value = renderGoal
@@ -122,12 +144,37 @@ object Baritone : Module(
             it.maxFallHeightNoWater.value = maxFallHeightNoWater
             it.allowWaterBucketFall.value = allowWaterBucketFall
             it.maxFallHeightBucket.value = maxFallHeightBucket
+            /* Build */
+            it.buildInLayers.value = buildInLayers
+            it.layerOrder.value = layerOrder
+            it.layerHeight.value = layerHeight
+            it.startAtLayer.value = startAtLayer
+            it.skipFailedLayers.value = skipFailedLayers
+            it.buildOnlySelection.value = buildOnlySelection
+            it.buildIgnoreExisting.value = buildIgnoreExisting
+            it.buildIgnoreDirection.value = buildIgnoreDirection
+            it.mapArtMode.value = mapArtMode
+            it.schematicOrientationX.value = schematicOrientationX
+            it.schematicOrientationY.value = schematicOrientationY
+            it.schematicOrientationZ.value = schematicOrientationZ
+            it.okIfWater.value = okIfWater
+            it.incorrectSize.value = incorrectSize
             /* Advanced */
+            it.preferSilkTouch.value = preferSilkTouch
+            it.backfill.value = backfill
+            it.chunkCaching.value = chunkCaching
             it.blockReachDistance.value = blockReachDistance
             it.enterPortal.value = enterPortals
             it.blockPlacementPenalty.value = blockPlacementPenalty.toDouble()
             it.jumpPenalty.value = jumpPenalty.toDouble()
             it.assumeWalkOnWater.value = assumeWalkOnWater
+            it.assumeStep.value = assumeStep
+            it.assumeExternalAutoTool.value = assumeExternalAutoTool
+            it.autoTool.value = autoTool
+            it.assumeSafeWalk.value = assumeSafeWalk
+            it.allowJumpAt256.value = allowJumpAt256
+            it.allowDiagonalDescend.value = allowDiagonalDescend
+            it.allowDiagonalAscend.value = allowDiagonalAscend
             it.failureTimeoutMS.value = failureTimeout * 1000L
             it.avoidance.value = avoidance
             it.mobAvoidanceRadius.value = mobAvoidanceRadius


### PR DESCRIPTION
**Describe the pull**
Updates Baritone to 1.2.17

You may need to do `./gradlew --refresh-dependencies` on local machine for the `cabaletta:baritone-api:1.2` dep to pick up the latest 1.2.17 release. I've set the "changing" property so the cache should only last 24h.
