### PR TITLE
CollectionSetting backwards compatibility

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/modules/player/InventoryManager.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/player/InventoryManager.kt
@@ -47,7 +47,7 @@ object InventoryManager : Module(
     private val pauseMovement by setting("Pause Movement", true)
     private val delay by setting("Delay Ticks", 1, 0..20, 1, unit = " ticks")
     private val helpMend by setting("Help Mend", false, description = "Helps mending items by replacing the offhand item with low HP items of the same type")
-    val ejectList = setting(CollectionSetting("Eject List", defaultEjectList, String::class.java))
+    val ejectList = setting(CollectionSetting("Eject List", defaultEjectList))
 
     enum class State {
         IDLE, SAVING_ITEM, HELPING_MEND, REFILLING_BUILDING, REFILLING, EJECTING

--- a/src/main/kotlin/com/lambda/client/module/modules/player/Scaffold.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/player/Scaffold.kt
@@ -67,8 +67,8 @@ object Scaffold : Module(
     private val thickness by setting("Outline Thickness", 2f, .25f..4f, .25f, { outline && page == Page.RENDER }, description = "Changes thickness of the outline")
     private val pendingBlockColor by setting("Pending Color", ColorHolder(0, 0, 255), visibility = { page == Page.RENDER })
 
-    val blockSelectionWhitelist = setting(CollectionSetting("BlockWhitelist", linkedSetOf("minecraft:obsidian"), String::class.java, { false }))
-    val blockSelectionBlacklist = setting(CollectionSetting("BlockBlacklist", blockBlacklist.map { it.registryName.toString() }.toMutableSet(), String::class.java, { false }))
+    val blockSelectionWhitelist = setting(CollectionSetting("BlockWhitelist", linkedSetOf("minecraft:obsidian"), { false }))
+    val blockSelectionBlacklist = setting(CollectionSetting("BlockBlacklist", blockBlacklist.map { it.registryName.toString() }.toMutableSet(), { false }))
 
     private enum class Page {
         GENERAL, RENDER

--- a/src/main/kotlin/com/lambda/client/module/modules/render/Search.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/render/Search.kt
@@ -70,10 +70,10 @@ object Search : Module(
     private val hideF1 by setting("Hide on F1", true)
 
     var overrideWarning by setting("Override Warning", false, { false })
-    val blockSearchList = setting(CollectionSetting("Search List", defaultSearchList, String::class.java, { false }))
-    val entitySearchList = setting(CollectionSetting("Entity Search List", linkedSetOf(EntityList.getKey((EntityItemFrame::class.java))!!.path), String::class.java, { false }))
-    val blockSearchDimensionFilter = setting(CollectionSetting("Block Dimension Filter", linkedSetOf(), DimensionFilter::class.java, { false }))
-    val entitySearchDimensionFilter = setting(CollectionSetting("Entity Dimension Filter", linkedSetOf(), DimensionFilter::class.java, { false }))
+    val blockSearchList = setting(CollectionSetting("Search List", defaultSearchList, { false }))
+    val entitySearchList = setting(CollectionSetting("Entity Search List", linkedSetOf(EntityList.getKey((EntityItemFrame::class.java))!!.path), { false }))
+    val blockSearchDimensionFilter = setting(CollectionSetting("Block Dimension Filter", linkedSetOf(), entryType = DimensionFilter::class.java, visibility = { false }))
+    val entitySearchDimensionFilter = setting(CollectionSetting("Entity Dimension Filter", linkedSetOf(), entryType = DimensionFilter::class.java, visibility = { false }))
 
     private val blockRenderer = ESPRenderer()
     private val entityRenderer = ESPRenderer()

--- a/src/main/kotlin/com/lambda/client/module/modules/render/Xray.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/render/Xray.kt
@@ -14,7 +14,7 @@ object Xray : Module(
 ) {
     private val defaultVisibleList = linkedSetOf("minecraft:diamond_ore", "minecraft:iron_ore", "minecraft:gold_ore", "minecraft:portal", "minecraft:cobblestone")
 
-    val visibleList = setting(CollectionSetting("Visible List", defaultVisibleList, String::class.java, { false }))
+    val visibleList = setting(CollectionSetting("Visible List", defaultVisibleList, { false }))
 
     @JvmStatic
     fun shouldReplace(state: IBlockState): Boolean {


### PR DESCRIPTION
**Describe the pull**
Makes [CollectionSetting change](https://github.com/lambda-client/lambda/commit/77d66d9c13e85df3e8a5a21447208d5b9bcf77cf#diff-e1c326b4a0cc53c6a2a802cfd0529a9cf21e3ccee2b10d904252225ac64f81dd) that allows empty collections to be compatible with existing plugins/modules like HighwayTools

**Describe how this pull is helpful**
HWT (or other plugins with CollectionSettings) doesn't work on latest nightly due to the CollectionSetting change. Maintaining backwards compatibility is preferable to breaking plugins.