### PR TITLE
Publish Lambda API with Maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
 
 plugins {
     id 'org.jetbrains.kotlin.jvm' version "$kotlinVersion"
+    id 'maven-publish'
 }
 
 apply plugin: 'net.minecraftforge.gradle'
@@ -198,7 +199,11 @@ reobf {
     }
 }
 
-artifacts {
-    shadowJar
+publishing {
+    publications {
+        api(MavenPublication) {
+            artifact source: buildApi, classifier: null
+            artifact source: buildApiSource, classifier: 'sources'
+        }
+    }
 }
-


### PR DESCRIPTION
**Describe the pull**
Allows plugins to use Maven to pull in the lambda api jar instead of copy pasting jar's around like cavemen. 

This only publishes to local maven which will be picked up by [jitpack](jitpack.io) builds, this is what i'd recommended for ease of use in lieu of lambda's own maven repo. 

**Describe how this pull is helpful**
Allow for easier updating of api jars for plugin devs. Also removes the jars as an attack vector for rogue plugin devs.

**Additional context**
What this would look like in a plugin's build.gradle:

```
dependencies {
    implementation 'com.github.rfresh2:lambda:17b1c0c842'
    ...
```
This of course is linked to my own repo and commit hash for example's sake. 
It can be linked to the main lambda repo and a named official release after this is merged.

You can view the various versions jitpack creates by browsing here for example: https://jitpack.io/#rfresh2/lambda/

