### PR TITLE
Write a simple LongJump for Old and Updated NCP

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/modules/movement/LongJump.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/LongJump.kt
@@ -1,0 +1,198 @@
+package com.lambda.client.module.modules.movement
+
+import com.lambda.client.commons.interfaces.DisplayEnum
+import com.lambda.client.event.events.PacketEvent
+import com.lambda.client.event.events.PlayerMoveEvent
+import com.lambda.client.module.Category
+import com.lambda.client.module.Module
+import com.lambda.client.util.BaritoneUtils
+import com.lambda.client.util.MovementUtils.applySpeedPotionEffects
+import com.lambda.client.util.MovementUtils.calcMoveYaw
+import com.lambda.client.util.MovementUtils.isInputting
+import com.lambda.client.util.threads.safeListener
+import net.minecraft.network.play.server.SPacketPlayerPosLook
+import net.minecraftforge.fml.common.gameevent.TickEvent
+import kotlin.math.cos
+import kotlin.math.hypot
+import kotlin.math.sin
+
+
+/**
+ * @author Doogie13
+ * @since 17/03/2023
+ */
+object LongJump : Module(
+    name = "LongJump",
+    description = "Allows you to abuse velocity to jump further",
+    category = Category.MOVEMENT
+) {
+
+    private val mode by setting("Mode", Mode.STANDARD, description = "How to boost your motion")
+    private var speed by setting("Speed", 3.8, 0.0..10.0, 0.001, description = "How much to boost your initial motion")
+
+    private val virtue by setting("Glide", false, description = "Glide along the ground after jumping") // reasonably major 2014 exploit, works on UpdatedNCP in 2023
+
+    enum class Mode(override val displayName: String) : DisplayEnum {
+        STANDARD("Standard"),
+        UPDATED("UpdatedNCP")
+    }
+
+    private var currentSpeed = .2873
+    private var strafePhase = StandardPhase.HEAD_START
+    private var lastDistance = 0.0
+    private var jumpTick = 0
+
+    init {
+
+        onEnable {
+            strafePhase = StandardPhase.HEAD_START
+            currentSpeed = .2873
+            lastDistance = 0.0
+            jumpTick = 0
+        }
+
+        safeListener<PacketEvent.Receive> {
+            if (it.packet is SPacketPlayerPosLook) {
+                currentSpeed = .0
+                disable()
+            }
+        }
+
+        safeListener<TickEvent.ClientTickEvent> {
+
+            if (it.phase != TickEvent.Phase.START)
+                return@safeListener
+
+            lastDistance = hypot(player.posX - player.lastTickPosX, player.posZ - player.lastTickPosZ)
+
+        }
+
+        safeListener<PlayerMoveEvent> {
+
+            val base = applySpeedPotionEffects(.2873)
+            val adjSpeed = speed * base // this seems to be what future uses so its what people are expecting
+            val yaw = calcMoveYaw()
+
+            if (player.capabilities.isFlying
+                || player.isElytraFlying
+                || BaritoneUtils.isPathing
+                || !isInputting) {
+                strafePhase = StandardPhase.HEAD_START
+                return@safeListener
+            }
+
+            when (mode) {
+
+                Mode.STANDARD -> {
+
+                    when (strafePhase) {
+
+                        StandardPhase.HEAD_START -> {
+                            if (!player.onGround) {
+                                strafePhase = StandardPhase.SLOWDOWN
+                                return@safeListener
+                            }
+                            currentSpeed = adjSpeed / 2.149
+                            strafePhase = StandardPhase.ACCELERATING
+                        }
+
+                        StandardPhase.ACCELERATING -> {
+                            currentSpeed = adjSpeed
+                            player.motionY = .424 // slightly higher than normal which is good for LJ
+                            strafePhase = StandardPhase.SLOWDOWN
+                        }
+
+                        StandardPhase.SLOWDOWN -> {
+                            currentSpeed -= .66 * base
+                            strafePhase = StandardPhase.FALLING
+                        }
+
+                        StandardPhase.FALLING -> {
+
+                            if (player.onGround) {
+                                strafePhase = StandardPhase.ACCELERATING
+                                return@safeListener
+                            }
+
+                            currentSpeed = lastDistance - lastDistance / 159
+                        }
+
+                    }
+
+                    it.x = -sin(yaw) * currentSpeed
+                    it.z = cos(yaw) * currentSpeed
+
+                    if (
+                        virtue
+                        && isInputting
+                        && world.collidesWithAnyBlock(player.entityBoundingBox.shrink(0.0625).expand(0.0, -0.55, 0.0))
+                        && player.motionY < 0
+                        && currentSpeed > .29
+                        && strafePhase == StandardPhase.FALLING
+                    ) {
+                        it.y = -1e-7
+                    }
+
+                }
+
+                Mode.UPDATED -> {
+
+                    // we cannot spam this on UpdatedNCP
+                    if (jumpTick > 1 && player.onGround) {
+                        disable()
+                        return@safeListener
+                    }
+
+                    if (player.onGround) {
+                        player.jump()
+                        it.x = -sin(yaw) * base
+                        it.z = cos(yaw) * base
+                        jumpTick = 1
+                        return@safeListener
+                    }
+
+                    if (++jumpTick == 2) {
+                        it.x = -sin(yaw) * adjSpeed
+                        it.z = cos(yaw) * adjSpeed
+                        return@safeListener
+                    }
+
+                    if (jumpTick < 8) {
+                        val newSpeed = lastDistance - lastDistance / 159
+                        it.x = -sin(yaw) * newSpeed
+                        it.z = cos(yaw) * newSpeed
+                    }
+
+                    if (
+                        virtue
+                        && isInputting
+                        && world.collidesWithAnyBlock(player.entityBoundingBox.shrink(0.0625).expand(0.0, -0.55, 0.0))
+                        && player.motionY < 0
+                        && currentSpeed > .29
+                    ) {
+                        it.y = -1e-7
+                    }
+
+                }
+
+            }
+
+        }
+
+    }
+
+    private enum class StandardPhase {
+        // slide along the ground slower to bypass
+        HEAD_START,
+
+        // to jump and accelerate
+        ACCELERATING,
+
+        // to fall to the ground
+        SLOWDOWN,
+
+        // to slowly fall to the ground
+        FALLING
+    }
+
+}

--- a/src/main/kotlin/com/lambda/client/module/modules/movement/LongJump.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/LongJump.kt
@@ -29,8 +29,8 @@ object LongJump : Module(
 
     private val mode by setting("Mode", Mode.STANDARD, description = "How to boost your motion")
     private var speed by setting("Speed", 3.8, 0.0..10.0, 0.001, description = "How much to boost your initial motion")
-
-    private val virtue by setting("Glide", false, description = "Glide along the ground after jumping") // reasonably major 2014 exploit, works on UpdatedNCP in 2023
+    private val virtue by setting("Glide", false, description = "Glide along the ground after jumping") // extends the boost from LJ. reasonably major 2014 exploit, works on UpdatedNCP in 2023
+    private val applyPots by setting("Apply Speed Pots", true, description = "Whether to apply Speed potion effect") // sometimes we don't want to due to some arbitrary top speed
 
     enum class Mode(override val displayName: String) : DisplayEnum {
         STANDARD("Standard"),
@@ -69,8 +69,8 @@ object LongJump : Module(
 
         safeListener<PlayerMoveEvent> {
 
-            val base = applySpeedPotionEffects(.2873)
-            val adjSpeed = speed * base // this seems to be what future uses so its what people are expecting
+            val base = if (applyPots) applySpeedPotionEffects(.2873) else .2873
+            val adjSpeed = speed * base // this seems to be what future does so its what people are expecting
             val yaw = calcMoveYaw()
 
             if (player.capabilities.isFlying

--- a/src/main/kotlin/com/lambda/client/module/modules/movement/Speed.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/Speed.kt
@@ -4,10 +4,8 @@ import com.lambda.client.commons.interfaces.DisplayEnum
 import com.lambda.client.event.SafeClientEvent
 import com.lambda.client.event.events.PacketEvent
 import com.lambda.client.event.events.PlayerMoveEvent
-import com.lambda.client.event.events.PlayerTravelEvent
 import com.lambda.client.manager.managers.TimerManager.modifyTimer
 import com.lambda.client.manager.managers.TimerManager.resetTimer
-import com.lambda.client.mixin.extension.isInWeb
 import com.lambda.client.mixin.extension.playerY
 import com.lambda.client.module.Category
 import com.lambda.client.module.Module
@@ -16,13 +14,8 @@ import com.lambda.client.util.EntityUtils.isInOrAboveLiquid
 import com.lambda.client.util.MovementUtils
 import com.lambda.client.util.MovementUtils.applySpeedPotionEffects
 import com.lambda.client.util.MovementUtils.calcMoveYaw
-import com.lambda.client.util.MovementUtils.setSpeed
-import com.lambda.client.util.MovementUtils.speed
-import com.lambda.client.util.TickTimer
-import com.lambda.client.util.TimeUnit
 import com.lambda.client.util.threads.runSafe
 import com.lambda.client.util.threads.safeListener
-import net.minecraft.client.settings.KeyBinding
 import net.minecraft.network.play.client.CPacketPlayer
 import net.minecraft.network.play.server.SPacketPlayerPosLook
 import net.minecraftforge.fml.common.gameevent.TickEvent
@@ -43,12 +36,9 @@ object Speed : Module(
     val mode = setting("Mode", SpeedMode.STRAFE)
 
     // Strafe settings
-    private val strafeAirSpeedBoost by setting("Air Speed Boost", 0.028f, 0.01f..0.04f, 0.001f, { mode.value == SpeedMode.STRAFE })
-    private val strafeTimerBoost by setting("Timer Boost", true, { mode.value == SpeedMode.STRAFE })
-    private val strafeAutoJump by setting("Auto Jump", true, { mode.value == SpeedMode.STRAFE }, description = "WARNING: Food intensive!")
-    private val strafeOnlyOverhead by setting("Only strafe on overhead", false, { mode.value == SpeedMode.STRAFE && strafeAutoJump })
+    private val strafeAirSpeedBoost by setting("Strafe Speed", StrafeMode.Normal)
+    private val strafeOnlyOverhead by setting("Require Roof", false, { mode.value == SpeedMode.STRAFE })
     private val strafeOnHoldingSprint by setting("On Holding Sprint", false, { mode.value == SpeedMode.STRAFE })
-    private val strafeCancelInertia by setting("Cancel Inertia", false, { mode.value == SpeedMode.STRAFE })
 
     // YPort settings
     private val yPortAccelerate by setting("Accelerate", true, { mode.value == SpeedMode.YPORT })
@@ -58,17 +48,17 @@ object Speed : Module(
     private val yPortAcceleration by setting("Acceleration Speed", 2.149, 1.0..5.0, 0.001, { mode.value == SpeedMode.YPORT })
     private val yPortDecay by setting("Decay Amount", 0.66, 0.0..1.0, 0.001, { mode.value == SpeedMode.YPORT })
 
-    private const val TIMER_SPEED = 45.955883f
-
-    // Strafe Mode
-    private var jumpTicks = 0
-    private val strafeTimer = TickTimer(TimeUnit.TICKS)
+    private const val TIMER_SPEED = 45.922115f
 
     // yport stuff
     private var currentSpeed = .2873
     private var currentY = 0.0
-    private var phase: YPortPhase = YPortPhase.WALKING
-    private var prevPhase: YPortPhase = YPortPhase.WALKING
+
+    private var strafePhase = StrafePhase.ACCELERATING
+
+    private var yPortPhase = YPortPhase.WALKING
+    private var prevYPortPhase = YPortPhase.WALKING
+
     private var goUp = false
     private var lastDistance = 0.0
 
@@ -85,16 +75,30 @@ object Speed : Module(
         FALLING
     }
 
+    private enum class StrafePhase {
+        // to jump and accelerate
+        ACCELERATING,
+        // to fall to the ground
+        SLOWDOWN,
+        // to slowly fall to the ground
+        FALLING
+    }
+
     enum class SpeedMode(override val displayName: String) : DisplayEnum {
         STRAFE("Strafe"),
         YPORT("YPort")
     }
 
+    enum class StrafeMode {
+        Normal, Strict
+    }
+
     init {
         onEnable {
             currentSpeed = .2873
-            phase = YPortPhase.WALKING
-            prevPhase = YPortPhase.WALKING
+            strafePhase = StrafePhase.ACCELERATING
+            yPortPhase = YPortPhase.WALKING
+            prevYPortPhase = YPortPhase.WALKING
             goUp = false
             currentY = 0.0
         }
@@ -107,23 +111,12 @@ object Speed : Module(
 
         safeListener<TickEvent.ClientTickEvent> {
             lastDistance = hypot(player.posX - player.prevPosX, player.posZ - player.prevPosZ)
-            if (mode.value == SpeedMode.STRAFE
-                && shouldStrafe()
-            ) strafe()
         }
 
         safeListener<PlayerMoveEvent> {
             when (mode.value) {
                 SpeedMode.STRAFE -> {
-                    if (shouldStrafe()) {
-                        setSpeed(max(player.speed, applySpeedPotionEffects(0.2873)))
-                    } else {
-                        reset()
-                        if (strafeCancelInertia && !strafeTimer.tick(2L, false)) {
-                            player.motionX = 0.0
-                            player.motionZ = 0.0
-                        }
-                    }
+                    handleStrafe(it)
                 }
 
                 SpeedMode.YPORT -> {
@@ -152,14 +145,14 @@ object Speed : Module(
 
             if (currentY + unModOffset > 0)
                 offset += currentY
-            else if (yPortAirStrict && phase == YPortPhase.FALLING && prevPhase == YPortPhase.FALLING) {
+            else if (yPortAirStrict && yPortPhase == YPortPhase.FALLING && prevYPortPhase == YPortPhase.FALLING) {
 
                 var predictedY = currentY
                 predictedY -= 0.08
                 predictedY *= 0.9800000190734863 // 0.333200006 vs 0.341599999
 
                 if (predictedY + player.posY <= player.posY) {
-                    phase = YPortPhase.WAITING
+                    yPortPhase = YPortPhase.WAITING
                 }
             }
 
@@ -175,7 +168,7 @@ object Speed : Module(
             currentY = 0.0
             goUp = false
             // 3 extra ticks at base speed
-            phase = YPortPhase.WAITING
+            yPortPhase = YPortPhase.WAITING
         }
 
         mode.listeners.add {
@@ -183,47 +176,15 @@ object Speed : Module(
         }
     }
 
-    private fun SafeClientEvent.strafe() {
-        player.jumpMovementFactor = strafeAirSpeedBoost
-        // slightly slower timer speed bypasses better (1.088)
-        if (strafeTimerBoost) modifyTimer(TIMER_SPEED)
-
-        if ((Step.isDisabled || player.onGround) && strafeAutoJump) jump()
-
-        strafeTimer.reset()
-    }
-
     private fun SafeClientEvent.shouldStrafe(): Boolean =
         !player.capabilities.isFlying
             && !player.isElytraFlying
-            && !mc.gameSettings.keyBindSneak.isKeyDown
-            && (!strafeOnHoldingSprint || mc.gameSettings.keyBindSprint.isKeyDown)
             && !BaritoneUtils.isPathing
             && MovementUtils.isInputting
-            && !(player.isInOrAboveLiquid || player.isInWeb)
-            && (!strafeOnlyOverhead || world.collidesWithAnyBlock(player.entityBoundingBox.offset(.0,.42,.0)))
 
     private fun SafeClientEvent.reset() {
         player.jumpMovementFactor = 0.02f
         resetTimer()
-        jumpTicks = 0
-    }
-
-    private fun SafeClientEvent.jump() {
-        if (player.onGround && jumpTicks <= 0) {
-            if (player.isSprinting) {
-                val yaw = calcMoveYaw()
-                player.motionX -= sin(yaw) * 0.2
-                player.motionZ += cos(yaw) * 0.2
-            }
-
-            KeyBinding.setKeyBindState(mc.gameSettings.keyBindJump.keyCode, false)
-            player.motionY = 0.4
-            player.isAirBorne = true
-            jumpTicks = 5
-        }
-
-        jumpTicks--
     }
 
     private fun SafeClientEvent.handleBoost(event: PlayerMoveEvent) {
@@ -240,13 +201,13 @@ object Speed : Module(
 
         modifyTimer(TIMER_SPEED)
 
-        prevPhase = phase
+        prevYPortPhase = yPortPhase
 
-        when (phase) {
+        when (yPortPhase) {
             YPortPhase.ACCELERATING -> {
                 // NCP says hDistance < 2.15 * hDistanceBaseRef
                 currentSpeed *= yPortAcceleration
-                phase = if (yPortAirStrict) YPortPhase.FALLING else YPortPhase.SLOWDOWN
+                yPortPhase = if (yPortAirStrict) YPortPhase.FALLING else YPortPhase.SLOWDOWN
                 goUp = true
                 currentY = 0.0
             }
@@ -258,12 +219,12 @@ object Speed : Module(
                 } else {
                     .2873
                 }
-                phase = YPortPhase.ACCELERATING
+                yPortPhase = YPortPhase.ACCELERATING
                 goUp = false
             }
 
             YPortPhase.FALLING -> {
-                if (prevPhase == YPortPhase.WALKING) {
+                if (prevYPortPhase == YPortPhase.WALKING) {
                     currentSpeed = if (yPortAccelerate) {
                         lastDistance - yPortDecay * (lastDistance - .2873)
                     } else {
@@ -281,7 +242,7 @@ object Speed : Module(
 
             else -> {
                 currentSpeed = max(currentSpeed, .2873)
-                phase = YPortPhase.values()[phase.ordinal + 1 % YPortPhase.values().size]
+                yPortPhase = YPortPhase.values()[yPortPhase.ordinal + 1 % YPortPhase.values().size]
                 goUp = false
             }
         }
@@ -298,4 +259,69 @@ object Speed : Module(
 
         player.setVelocity(event.x, event.y, event.z)
     }
+
+    private fun SafeClientEvent.handleStrafe(event: PlayerMoveEvent) {
+
+        if (
+            !shouldStrafe()
+        ) {
+            resetTimer()
+            event.x = .0
+            event.z = .0
+            currentSpeed = .2873
+            return
+        }
+
+        if (!(!strafeOnlyOverhead || world.collidesWithAnyBlock(player.entityBoundingBox.offset(.0,.42,.0)))
+            || !(!strafeOnHoldingSprint || mc.gameSettings.keyBindSprint.isKeyDown))
+            return
+
+        modifyTimer(TIMER_SPEED)
+
+        val base = applySpeedPotionEffects(.2873)
+
+        if (player.onGround)
+            strafePhase = StrafePhase.ACCELERATING
+
+        when (strafePhase) {
+
+            StrafePhase.ACCELERATING -> {
+
+                if (player.onGround)
+                    event.y = .42
+                else
+                    strafePhase = StrafePhase.FALLING
+
+                currentSpeed = base
+                currentSpeed *= if (strafeAirSpeedBoost == StrafeMode.Strict) (1.87) else (1.93)
+
+                strafePhase = StrafePhase.SLOWDOWN
+
+            }
+
+            StrafePhase.SLOWDOWN -> {
+
+                currentSpeed -= .66 * base
+
+                strafePhase = StrafePhase.FALLING
+
+            }
+
+            StrafePhase.FALLING -> {
+
+                currentSpeed = lastDistance - lastDistance / 159
+
+            }
+
+        }
+
+        val yaw = calcMoveYaw()
+
+        currentSpeed = currentSpeed.coerceAtLeast(.2873)
+
+        event.x = -sin(yaw) * currentSpeed
+        event.z = cos(yaw) * currentSpeed
+
+    }
+
 }


### PR DESCRIPTION
**Describe the pull**
Creates a longjump for Old and New NCP

**Describe how this pull is helpful**
This is a useful enough feature that it shouldn't be delegated to an outdated plugin

**Additional context**
Standard mode works just as well as any on 2b2tpvp
UpdatedNCP mode works on eu.loyisa.cn and requires knockback from a bow or smth much sooner before activation
[Video](https://youtu.be/LgALA2b_dv4)