### PR TITLE
Seen, Playtime Commands + 2b2t queue API update

### DIFF
--- a/src/main/kotlin/com/lambda/client/command/commands/PlaytimeCommand.kt
+++ b/src/main/kotlin/com/lambda/client/command/commands/PlaytimeCommand.kt
@@ -3,6 +3,7 @@ package com.lambda.client.command.commands
 import com.google.gson.JsonParser
 import com.lambda.client.command.ClientCommand
 import com.lambda.client.commons.utils.ConnectionUtils
+import com.lambda.client.commons.utils.grammar
 import com.lambda.client.manager.managers.UUIDManager
 import com.lambda.client.util.text.MessageSendHelper
 
@@ -45,11 +46,9 @@ object PlaytimeCommand: ClientCommand(
         val days = (durationInSeconds % secondsInMonth) / secondsInDay
         val hours = (durationInSeconds % secondsInDay) / secondsInHour
         return buildString {
-            append(if(months > 0) "$months month${if(months != 1L) "s" else ""}, " else "")
-            append(if(days > 0) "$days day${if(days != 1L) "s" else ""}, " else "")
-            append(hours)
-            append(" hour")
-            append(if(hours != 1L) "s" else "")
+            append(if(months > 0) "${grammar(months.toInt(), "month", "months")}, " else "")
+            append(if(days > 0) "${grammar(days.toInt(), "day", "days")}, " else "")
+            append(grammar(hours.toInt(), "hour", "hours"))
         }
     }
 }

--- a/src/main/kotlin/com/lambda/client/command/commands/PlaytimeCommand.kt
+++ b/src/main/kotlin/com/lambda/client/command/commands/PlaytimeCommand.kt
@@ -6,6 +6,8 @@ import com.lambda.client.commons.utils.ConnectionUtils
 import com.lambda.client.commons.utils.grammar
 import com.lambda.client.manager.managers.UUIDManager
 import com.lambda.client.util.text.MessageSendHelper
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 object PlaytimeCommand: ClientCommand(
     name = "playtime",
@@ -17,38 +19,26 @@ object PlaytimeCommand: ClientCommand(
     init {
         string("playerName") { playerName ->
             executeAsync("Check a player's playtime on 2b2t") {
-                UUIDManager.getByName(playerName.value)?.let { profile ->
+                UUIDManager.getByName(playerName.value)?.let outer@ { profile ->
                     ConnectionUtils.requestRawJsonFrom("https://api.2b2t.vc/playtime?uuid=${profile.uuid}") {
                         MessageSendHelper.sendChatMessage("Failed querying playtime data for player: ${it.message}")
                     }?.let {
                         if (it.isEmpty()) {
                             MessageSendHelper.sendChatMessage("No data found for player: ${profile.name}")
-                            return@let
+                            return@outer
                         }
                         val jsonElement = parser.parse(it)
-                        val playtimeSeconds = jsonElement.asJsonObject["playtimeSeconds"].asInt
-                        MessageSendHelper.sendChatMessage("${profile.name} has played for ${formatDuration(playtimeSeconds.toLong())}")
+                        val playtimeSeconds = jsonElement.asJsonObject["playtimeSeconds"].asDouble
+                        MessageSendHelper.sendChatMessage("${profile.name} has played for ${
+                            playtimeSeconds.toDuration(DurationUnit.SECONDS)
+                        }")
                     }
-                } ?: run{
-                    MessageSendHelper.sendChatMessage("Failed to find player with name ${playerName.value}")
+
+                    return@executeAsync
                 }
+
+                MessageSendHelper.sendChatMessage("Failed to find player with name ${playerName.value}")
             }
-        }
-    }
-
-    private fun formatDuration(durationInSeconds: Long): String {
-        val secondsInMinute = 60L
-        val secondsInHour = secondsInMinute * 60L
-        val secondsInDay = secondsInHour * 24L
-        val secondsInMonth = secondsInDay * 30L // assuming 30 days per month
-
-        val months = durationInSeconds / secondsInMonth
-        val days = (durationInSeconds % secondsInMonth) / secondsInDay
-        val hours = (durationInSeconds % secondsInDay) / secondsInHour
-        return buildString {
-            append(if(months > 0) "${grammar(months.toInt(), "month", "months")}, " else "")
-            append(if(days > 0) "${grammar(days.toInt(), "day", "days")}, " else "")
-            append(grammar(hours.toInt(), "hour", "hours"))
         }
     }
 }

--- a/src/main/kotlin/com/lambda/client/command/commands/PlaytimeCommand.kt
+++ b/src/main/kotlin/com/lambda/client/command/commands/PlaytimeCommand.kt
@@ -1,0 +1,55 @@
+package com.lambda.client.command.commands
+
+import com.google.gson.JsonParser
+import com.lambda.client.command.ClientCommand
+import com.lambda.client.commons.utils.ConnectionUtils
+import com.lambda.client.manager.managers.UUIDManager
+import com.lambda.client.util.text.MessageSendHelper
+
+object PlaytimeCommand: ClientCommand(
+    name = "playtime",
+    alias = arrayOf("pt"),
+    description = "Check a player's playtime on 2b2t"
+) {
+    private val parser = JsonParser()
+
+    init {
+        string("playerName") { playerName ->
+            executeAsync("Check a player's playtime on 2b2t") {
+                UUIDManager.getByName(playerName.value)?.let { profile ->
+                    ConnectionUtils.requestRawJsonFrom("https://api.2b2t.vc/playtime?uuid=${profile.uuid}") {
+                        MessageSendHelper.sendChatMessage("Failed querying playtime data for player: ${it.message}")
+                    }?.let {
+                        if (it.isEmpty()) {
+                            MessageSendHelper.sendChatMessage("No data found for player: ${profile.name}")
+                            return@let
+                        }
+                        val jsonElement = parser.parse(it)
+                        val playtimeSeconds = jsonElement.asJsonObject["playtimeSeconds"].asInt
+                        MessageSendHelper.sendChatMessage("${profile.name} has played for ${formatDuration(playtimeSeconds.toLong())}")
+                    }
+                } ?: run{
+                    MessageSendHelper.sendChatMessage("Failed to find player with name ${playerName.value}")
+                }
+            }
+        }
+    }
+
+    private fun formatDuration(durationInSeconds: Long): String {
+        val secondsInMinute = 60L
+        val secondsInHour = secondsInMinute * 60L
+        val secondsInDay = secondsInHour * 24L
+        val secondsInMonth = secondsInDay * 30L // assuming 30 days per month
+
+        val months = durationInSeconds / secondsInMonth
+        val days = (durationInSeconds % secondsInMonth) / secondsInDay
+        val hours = (durationInSeconds % secondsInDay) / secondsInHour
+        return buildString {
+            append(if(months > 0) "$months month${if(months != 1L) "s" else ""}, " else "")
+            append(if(days > 0) "$days day${if(days != 1L) "s" else ""}, " else "")
+            append(hours)
+            append(" hour")
+            append(if(hours != 1L) "s" else "")
+        }
+    }
+}

--- a/src/main/kotlin/com/lambda/client/command/commands/SeenCommand.kt
+++ b/src/main/kotlin/com/lambda/client/command/commands/SeenCommand.kt
@@ -1,0 +1,43 @@
+package com.lambda.client.command.commands
+
+import com.google.gson.JsonParser
+import com.lambda.client.command.ClientCommand
+import com.lambda.client.commons.utils.ConnectionUtils
+import com.lambda.client.manager.managers.UUIDManager
+import com.lambda.client.util.text.MessageSendHelper
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+object SeenCommand : ClientCommand(
+    name = "seen",
+    alias = arrayOf("lastseen"),
+    description = "Check when a player was last seen"
+) {
+
+    private val parser = JsonParser()
+
+    init {
+        string("playerName") { playerName ->
+            executeAsync("Check when a player was last seen") {
+                UUIDManager.getByName(playerName.value)?.let { profile ->
+                    ConnectionUtils.requestRawJsonFrom("https://api.2b2t.vc/seen?uuid=${profile.uuid}") {
+                        MessageSendHelper.sendChatMessage("Failed querying seen data for player: ${it.message}")
+                    }?.let {
+                        if (it.isEmpty()) {
+                            MessageSendHelper.sendChatMessage("No data found for player: ${profile.name}")
+                            return@let
+                        }
+                        val jsonElement = parser.parse(it)
+                        val dateRaw = jsonElement.asJsonObject["time"].asString
+                        val parsedDate = ZonedDateTime.parse(dateRaw).withZoneSameInstant(ZoneId.systemDefault())
+                        val dateFormatter = DateTimeFormatter.ofLocalizedDateTime(java.time.format.FormatStyle.LONG)
+                        MessageSendHelper.sendChatMessage("${profile.name} was last seen on ${parsedDate.format(dateFormatter)}")
+                    }
+                } ?: run {
+                    MessageSendHelper.sendChatMessage("Failed to find player with name ${playerName.value}")
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/lambda/client/commons/utils/ConnectionUtils.kt
+++ b/src/main/kotlin/com/lambda/client/commons/utils/ConnectionUtils.kt
@@ -1,13 +1,15 @@
 package com.lambda.client.commons.utils
 
 import com.lambda.client.module.modules.client.Plugins
+import java.net.HttpURLConnection
 import java.net.URL
-import javax.net.ssl.HttpsURLConnection
 
 object ConnectionUtils {
 
     fun requestRawJsonFrom(url: String, catch: (Exception) -> Unit = { it.printStackTrace() }): String? {
         return runConnection(url, { connection ->
+            connection.setRequestProperty("User-Agent", "LambdaClient")
+            connection.setRequestProperty("Connection", "close")
             connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8")
             if (Plugins.token.isNotBlank()) connection.setRequestProperty("Authorization", "token ${Plugins.token}")
             connection.requestMethod = "GET"
@@ -15,8 +17,8 @@ object ConnectionUtils {
         }, catch)
     }
 
-    fun <T> runConnection(url: String, block: (HttpsURLConnection) -> T?, catch: (Exception) -> Unit = { it.printStackTrace() }): T? {
-        (URL(url).openConnection() as HttpsURLConnection).run {
+    fun <T> runConnection(url: String, block: (HttpURLConnection) -> T?, catch: (Exception) -> Unit = { it.printStackTrace() }): T? {
+        (URL(url).openConnection() as HttpURLConnection).run {
             return try {
                 doOutput = true
                 doInput = true
@@ -29,5 +31,4 @@ object ConnectionUtils {
             }
         }
     }
-
 }

--- a/src/main/kotlin/com/lambda/client/gui/hudgui/elements/misc/Queue2B2T.kt
+++ b/src/main/kotlin/com/lambda/client/gui/hudgui/elements/misc/Queue2B2T.kt
@@ -68,27 +68,28 @@ internal object Queue2B2T : LabelHud(
         if (NetworkManager.isOffline) {
             displayText.addLine("Cannot connect to api.2b2t.vc", primaryColor)
             displayText.add("Make sure your internet is working!", primaryColor)
-        } else {
-            if (showPriority) {
-                displayText.add("Priority: ", primaryColor)
-                displayText.add("${queueData.prio}", secondaryColor)
-            }
+            return
+        }
 
-            if (showRegular) {
-                displayText.add("Regular: ", primaryColor)
-                displayText.add("${queueData.regular}", secondaryColor)
-            }
-            if (showUpdatedTime) {
-                displayText.addLine("", primaryColor)
-                displayText.add("Last updated $lastUpdate ago", primaryColor)
-            }
+        if (showPriority) {
+            displayText.add("Priority: ", primaryColor)
+            displayText.add("${queueData.prio}", secondaryColor)
+        }
+
+        if (showRegular) {
+            displayText.add("Regular: ", primaryColor)
+            displayText.add("${queueData.regular}", secondaryColor)
+        }
+        if (showUpdatedTime) {
+            displayText.addLine("", primaryColor)
+            displayText.add("Last updated $lastUpdate ago", primaryColor)
         }
     }
 
     private fun sendWarning() {
         MessageSendHelper.sendWarningMessage(
             "This module uses an external API, api.2b2t.vc, which is operated by rfresh#2222." +
-                "If you do not trust this external API / have not verified the safety yourself, disable this HUD component."
+                " If you do not trust this external API / have not verified the safety yourself, disable this HUD component."
         )
         hasShownWarning.value = true
     }
@@ -101,9 +102,10 @@ internal object Queue2B2T : LabelHud(
                 }?.let {
                     gson.fromJson(it, QueueData::class.java)?.let { data ->
                         queueData = data
-                    } ?: run {
-                        LambdaMod.LOG.error("No queue data received. Is 2b2t down?")
+                        return@runCatching
                     }
+
+                    LambdaMod.LOG.error("No queue data received. Is 2b2t down?")
                 }
             }
         }


### PR DESCRIPTION
Adds commands to get 2b2t playtime and last seen data from my API: [api.2b2t.vc](https://api.2b2t.vc) which sources its data from my proxy fleet.
```
;seen rfresh2
;playtime rfresh2
```

I've also updated the 2b2t queue hud element to my API as it previously wasn't working and my data seems to be more frequently updated.
