### PR TITLE
ElytraFlight vanilla crash fix

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/modules/misc/ElytraFix.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/misc/ElytraFix.kt
@@ -35,6 +35,6 @@ object ElytraFix : Module(
         && entity.world.loadedEntityList
         .filterIsInstance<AccessorEntityFireworkRocket>()
         .any {
-            it.boostedEntity.equals(entity)
+            it.boostedEntity === entity
         }
 }

--- a/src/main/kotlin/com/lambda/client/module/modules/movement/ElytraFlight.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/ElytraFlight.kt
@@ -128,9 +128,8 @@ object ElytraFlight : Module(
     private var boostingTick = 0
 
     /* Vanilla mode state */
-    private var lastY = 0.0
-    private var shouldDescend = false
-    private var lastHighY = 0.0
+    private var firstY = 0.0
+    private var secondY = 0.0
 
     /* Event Listeners */
     init {
@@ -483,26 +482,14 @@ object ElytraFlight : Module(
         event.cancel()
     }
 
-    private fun SafeClientEvent.vanillaMode() {
-        val playerY = player.posY
-        val lastShouldDescend = shouldDescend
-        val isBoosted = world.getLoadedEntityList().any { it is EntityFireworkRocket && it.boostedEntity == player }
-
-        shouldDescend = lastY > playerY && lastHighY - 60 < playerY
-
-        packetPitch = if (isBoosted) {
-            -rocketPitch
-        } else if (shouldDescend) {
-            if (!lastShouldDescend) {
-                lastHighY = playerY
-            }
-            downPitch
-        } else {
-            -upPitch
-        }
-
-        lastY = playerY
-    }
+private fun SafeClientEvent.vanillaMode() {
+    secondY = player.posY
+    packetPitch = when {
+        world.loadedEntityList.any { it is EntityFireworkRocket && it.boostedEntity == player } -> -rocketPitch
+        firstY - secondY > 0 -> downPitch
+        else -> -upPitch}
+    firstY = player.posY
+}
 
     fun shouldSwing(): Boolean {
         return isEnabled && isFlying && !autoLanding && (mode.value == ElytraFlightMode.CONTROL || mode.value == ElytraFlightMode.PACKET)


### PR DESCRIPTION
**Describe the pull**
<!-- A clear and concise description of what the pull is for. -->
The game would crash if ElytraFlight was set to vanilla and a firework was used. The upPitch would get stuck on when it should use downPitch.

**Describe how this pull is helpful**
<!-- A clear description of why this should be merged -->
Crash fix. This also increases vanilla ElytraFlight reliability with improved code.

**Additional context**
<!-- Add any other context about the pull here. -->
The crash was caused by java code not properly converted to Kotlin. https://github.com/lambda-client/lambda/commit/81e9f30dcbd389658ab3a7cdd3b29eef51d42fda