### PR TITLE
Improve GUI responsiveness and jank

### DIFF
--- a/src/main/kotlin/com/lambda/client/LambdaMod.kt
+++ b/src/main/kotlin/com/lambda/client/LambdaMod.kt
@@ -1,6 +1,8 @@
 package com.lambda.client
 
 import com.lambda.client.event.ForgeEventProcessor
+import com.lambda.client.event.LambdaEventBus
+import com.lambda.client.event.events.RealWorldTickEvent
 import com.lambda.client.gui.clickgui.LambdaClickGui
 import com.lambda.client.util.ConfigUtils
 import com.lambda.client.util.KamiCheck
@@ -70,8 +72,6 @@ class LambdaMod {
         ConfigUtils.moveAllLegacyConfigs()
         ConfigUtils.loadAll()
 
-        BackgroundScope.start()
-
         WebUtils.updateCheck()
         LambdaClickGui.populateRemotePlugins()
 
@@ -83,5 +83,9 @@ class LambdaMod {
     @Mod.EventHandler
     fun postInit(event: FMLPostInitializationEvent) {
         ready = true
+        BackgroundScope.launchLooping("RealWorldTick", 50L) {
+            LambdaEventBus.post(RealWorldTickEvent())
+        }
+        BackgroundScope.start()
     }
 }

--- a/src/main/kotlin/com/lambda/client/event/events/RealWorldTickEvent.kt
+++ b/src/main/kotlin/com/lambda/client/event/events/RealWorldTickEvent.kt
@@ -1,0 +1,5 @@
+package com.lambda.client.event.events
+
+import com.lambda.client.event.Event
+
+class RealWorldTickEvent : Event

--- a/src/main/kotlin/com/lambda/client/gui/AbstractLambdaGui.kt
+++ b/src/main/kotlin/com/lambda/client/gui/AbstractLambdaGui.kt
@@ -1,6 +1,8 @@
 package com.lambda.client.gui
 
+import com.lambda.client.event.events.RealWorldTickEvent
 import com.lambda.client.event.events.RenderOverlayEvent
+import com.lambda.client.event.listener.listener
 import com.lambda.client.gui.rgui.WindowComponent
 import com.lambda.client.gui.rgui.windows.ColorPicker
 import com.lambda.client.gui.rgui.windows.SettingWindow
@@ -14,13 +16,11 @@ import com.lambda.client.util.graphics.*
 import com.lambda.client.util.graphics.font.FontRenderAdapter
 import com.lambda.client.util.math.Vec2d
 import com.lambda.client.util.math.Vec2f
-import com.lambda.client.util.threads.safeListener
 import com.lambda.mixin.accessor.gui.AccessorGuiScreen
 import net.minecraft.client.gui.GuiScreen
 import net.minecraft.client.gui.ScaledResolution
 import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.util.ResourceLocation
-import net.minecraftforge.fml.common.gameevent.TickEvent
 import org.lwjgl.input.Keyboard
 import org.lwjgl.input.Mouse
 import org.lwjgl.opengl.GL11.*
@@ -86,9 +86,7 @@ abstract class AbstractLambdaGui<S : SettingWindow<*>, E : Any> : GuiScreen() {
         mc = Wrapper.minecraft
         windowList.add(ColorPicker)
 
-        safeListener<TickEvent.ClientTickEvent> { event ->
-            if (event.phase != TickEvent.Phase.START) return@safeListener
-
+        listener<RealWorldTickEvent> {
             blurShader.shader?.let { shaderGroup ->
                 val multiplier = ClickGUI.blur * fadeMultiplier
                 shaderGroup.listShaders.forEach { shader ->
@@ -101,7 +99,7 @@ abstract class AbstractLambdaGui<S : SettingWindow<*>, E : Any> : GuiScreen() {
             }
         }
 
-        safeListener<RenderOverlayEvent>(-69420) {
+        listener<RenderOverlayEvent>(-69420) {
             if (!displayed.value && fadeMultiplier > 0.0f) {
                 drawScreen(0, 0, mc.renderPartialTicks)
             }
@@ -269,6 +267,7 @@ abstract class AbstractLambdaGui<S : SettingWindow<*>, E : Any> : GuiScreen() {
 
     // Rendering
     final override fun drawScreen(mouseX: Int, mouseY: Int, partialTicks: Float) {
+        handleInput()
         val scale = ClickGUI.getScaleFactorFloat()
         val scaledResolution = ScaledResolution(mc)
         val multiplier = fadeMultiplier

--- a/src/main/kotlin/com/lambda/client/gui/clickgui/LambdaClickGui.kt
+++ b/src/main/kotlin/com/lambda/client/gui/clickgui/LambdaClickGui.kt
@@ -273,6 +273,7 @@ object LambdaClickGui : AbstractLambdaGui<ModuleSettingWindow, AbstractModule>()
         val allButtons = ModuleManager.modules
             .groupBy { it.category.displayName }
             .mapValues { (_, modules) -> modules.map { ModuleButton(it) } }
+        allButtons.forEach { it.value.forEach { it.onGuiInit() }}
 
         windows.filter { window ->
             window != pluginWindow

--- a/src/main/kotlin/com/lambda/client/gui/hudgui/AbstractHudElement.kt
+++ b/src/main/kotlin/com/lambda/client/gui/hudgui/AbstractHudElement.kt
@@ -71,6 +71,7 @@ abstract class AbstractHudElement(
     }
 
     final override fun onRender(vertexHelper: VertexHelper, absolutePos: Vec2f) {
+        super.onRender(vertexHelper, absolutePos)
         renderFrame(vertexHelper)
         glScalef(scale, scale, scale)
         renderHud(vertexHelper)

--- a/src/main/kotlin/com/lambda/client/gui/hudgui/LambdaHudGui.kt
+++ b/src/main/kotlin/com/lambda/client/gui/hudgui/LambdaHudGui.kt
@@ -99,7 +99,7 @@ object LambdaHudGui : AbstractLambdaGui<HudSettingWindow, AbstractHudElement>() 
 
     init {
         safeListener<RenderOverlayEvent>(0) {
-            if (Hud.isDisabled) return@safeListener
+            if (Hud.isDisabled || mc.currentScreen is LambdaHudGui) return@safeListener
 
             val vertexHelper = VertexHelper(GlStateUtils.useVbo())
             GlStateUtils.rescaleLambda()
@@ -117,6 +117,8 @@ object LambdaHudGui : AbstractLambdaGui<HudSettingWindow, AbstractHudElement>() 
     }
 
     private fun renderHudElement(vertexHelper: VertexHelper, window: AbstractHudElement) {
+        window.updatePrevPos()
+        window.updatePrevSize()
         glPushMatrix()
         glTranslatef(window.renderPosX, window.renderPosY, 0.0f)
 

--- a/src/main/kotlin/com/lambda/client/gui/rgui/Component.kt
+++ b/src/main/kotlin/com/lambda/client/gui/rgui/Component.kt
@@ -110,22 +110,22 @@ open class Component(
         updatePrevSize()
     }
 
-    open fun onTick() {
-        updatePrevPos()
-        updatePrevSize()
-    }
+    open fun onTick() {}
 
-    private fun updatePrevPos() {
+    fun updatePrevPos() {
         prevPosX = posX
         prevPosY = posY
     }
 
-    private fun updatePrevSize() {
+    fun updatePrevSize() {
         prevWidth = width
         prevHeight = height
     }
 
-    open fun onRender(vertexHelper: VertexHelper, absolutePos: Vec2f) {}
+    open fun onRender(vertexHelper: VertexHelper, absolutePos: Vec2f) {
+        updatePrevPos()
+        updatePrevSize()
+    }
 
     open fun onPostRender(vertexHelper: VertexHelper, absolutePos: Vec2f) {}
 

--- a/src/main/kotlin/com/lambda/client/gui/rgui/component/EnumSlider.kt
+++ b/src/main/kotlin/com/lambda/client/gui/rgui/component/EnumSlider.kt
@@ -16,16 +16,6 @@ class EnumSlider(val setting: EnumSetting<*>) : Slider(setting.name, 0.0, settin
     override val isBold
         get() = setting.isModified && ClickGUI.showModifiedInBold
 
-    override fun onTick() {
-        super.onTick()
-        if (mouseState != MouseState.DRAG) {
-            val settingValue = setting.value.ordinal
-            if (roundInput(value) != settingValue) {
-                value = (settingValue + settingValue / (enumValues.size - 1.0)) / enumValues.size.toDouble()
-            }
-        }
-    }
-
     override fun onRelease(mousePos: Vec2f, buttonId: Int) {
         super.onRelease(mousePos, buttonId)
         if (prevState != MouseState.DRAG) setting.nextValue()
@@ -44,6 +34,12 @@ class EnumSlider(val setting: EnumSetting<*>) : Slider(setting.name, 0.0, settin
     private fun roundInput(valueIn: Double) = floor(valueIn * enumValues.size).toInt().coerceIn(0, enumValues.size - 1)
 
     override fun onRender(vertexHelper: VertexHelper, absolutePos: Vec2f) {
+        if (mouseState != MouseState.DRAG) {
+            val settingValue = setting.value.ordinal
+            if (roundInput(value) != settingValue) {
+                value = (settingValue + settingValue / (enumValues.size - 1.0)) / enumValues.size.toDouble()
+            }
+        }
         val valueText = setting.value.readableName()
         protectedWidth = FontRenderAdapter.getStringWidth(valueText, 0.75f).toDouble()
 

--- a/src/main/kotlin/com/lambda/client/gui/rgui/component/Slider.kt
+++ b/src/main/kotlin/com/lambda/client/gui/rgui/component/Slider.kt
@@ -93,11 +93,17 @@ open class Slider(
 
     override fun onTick() {
         super.onTick()
+        visibility?.let { visible = it.invoke() }
+    }
+
+    override fun onGuiInit() {
+        super.onGuiInit()
         height = maxHeight
         visibility?.let { visible = it.invoke() }
     }
 
     override fun onRender(vertexHelper: VertexHelper, absolutePos: Vec2f) {
+        super.onRender(vertexHelper, absolutePos)
         // Slider bar
         if (renderProgress > 0.0) RenderUtils2D.drawRectFilled(vertexHelper, Vec2d(0.0, 0.0), Vec2d(renderWidth * renderProgress, renderHeight.toDouble()), GuiColors.primary)
 
@@ -135,6 +141,7 @@ open class Slider(
     }
 
     override fun onPostRender(vertexHelper: VertexHelper, absolutePos: Vec2f) {
+        super.onPostRender(vertexHelper, absolutePos)
         if (Tooltips.isDisabled || description.isBlank()) return
 
         var deltaTime = AnimationUtils.toDeltaTimeFloat(lastStateUpdateTime)

--- a/src/main/kotlin/com/lambda/client/gui/rgui/component/StringButton.kt
+++ b/src/main/kotlin/com/lambda/client/gui/rgui/component/StringButton.kt
@@ -10,8 +10,6 @@ import com.lambda.client.util.math.Vec2d
 import com.lambda.client.util.math.Vec2f
 import net.minecraft.client.gui.GuiScreen
 import org.lwjgl.input.Keyboard
-import kotlin.math.max
-import kotlin.math.min
 
 class StringButton(val setting: StringSetting) : BooleanSlider(setting.name, 1.0, setting.description, setting.visibility) {
 

--- a/src/main/kotlin/com/lambda/client/gui/rgui/windows/ListWindow.kt
+++ b/src/main/kotlin/com/lambda/client/gui/rgui/windows/ListWindow.kt
@@ -194,7 +194,10 @@ open class ListWindow(
         )
         glEnable(GL_SCISSOR_TEST)
         glTranslatef(0.0f, -renderScrollProgress, 0.0f)
-
+        children.forEach {
+            it.updatePrevSize()
+            it.updatePrevPos()
+        }
         children.filter {
             it.visible
                 && it.renderPosY + it.renderHeight - renderScrollProgress > draggableHeight
@@ -212,13 +215,10 @@ open class ListWindow(
     override fun onMouseInput(mousePos: Vec2f) {
         super.onMouseInput(mousePos)
         val relativeMousePos = mousePos.minus(posX, posY - renderScrollProgress)
+        updateHovered(relativeMousePos)
         if (Mouse.getEventDWheel() != 0) {
             scrollTimer.reset()
             scrollSpeed -= Mouse.getEventDWheel() * 0.1f
-            updateHovered(relativeMousePos)
-        }
-        if (mouseState != MouseState.DRAG) {
-            updateHovered(relativeMousePos)
         }
         if (!minimized) (hoveredChild as? InteractiveComponent)?.let {
             it.onMouseInput(getRelativeMousePos(mousePos, it))

--- a/src/main/kotlin/com/lambda/client/gui/rgui/windows/SettingWindow.kt
+++ b/src/main/kotlin/com/lambda/client/gui/rgui/windows/SettingWindow.kt
@@ -1,7 +1,6 @@
 package com.lambda.client.gui.rgui.windows
 
 import com.lambda.client.commons.extension.sumByFloat
-import com.lambda.client.gui.rgui.InteractiveComponent
 import com.lambda.client.gui.rgui.component.*
 import com.lambda.client.module.modules.client.ClickGUI
 import com.lambda.client.setting.settings.AbstractSetting
@@ -11,10 +10,8 @@ import com.lambda.client.setting.settings.impl.other.ColorSetting
 import com.lambda.client.setting.settings.impl.primitive.BooleanSetting
 import com.lambda.client.setting.settings.impl.primitive.EnumSetting
 import com.lambda.client.setting.settings.impl.primitive.StringSetting
-import com.lambda.client.util.graphics.font.FontRenderAdapter
 import com.lambda.client.util.math.Vec2f
 import org.lwjgl.input.Keyboard
-import org.lwjgl.input.Mouse
 
 abstract class SettingWindow<T : Any>(
     name: String,
@@ -50,6 +47,7 @@ abstract class SettingWindow<T : Any>(
                     else -> null
                 }?.also {
                     children.add(it)
+                    it.onGuiInit()
                 }
             }
             initialized = true


### PR DESCRIPTION
**Describe the pull**
Fixes various gui issues where components are not correctly positioned for a few frames on init.

Moves important position updates off the tick event and onto the render event, massively increasing responsiveness. 
More should be done to move gui stuff off ticks. Basically nothing that affects render updates should happen on tick events. I've also added a RealWorldTickEvent to help with responsiveness while timer is enabled.  

