### PR TITLE
ClickGui + Hud Improvements

### DIFF
--- a/src/main/kotlin/com/lambda/client/LambdaMod.kt
+++ b/src/main/kotlin/com/lambda/client/LambdaMod.kt
@@ -1,8 +1,6 @@
 package com.lambda.client
 
 import com.lambda.client.event.ForgeEventProcessor
-import com.lambda.client.event.LambdaEventBus
-import com.lambda.client.event.events.RealWorldTickEvent
 import com.lambda.client.gui.clickgui.LambdaClickGui
 import com.lambda.client.util.ConfigUtils
 import com.lambda.client.util.KamiCheck
@@ -83,9 +81,6 @@ class LambdaMod {
     @Mod.EventHandler
     fun postInit(event: FMLPostInitializationEvent) {
         ready = true
-        BackgroundScope.launchLooping("RealWorldTick", 50L) {
-            LambdaEventBus.post(RealWorldTickEvent())
-        }
         BackgroundScope.start()
     }
 }

--- a/src/main/kotlin/com/lambda/client/event/events/RealWorldTickEvent.kt
+++ b/src/main/kotlin/com/lambda/client/event/events/RealWorldTickEvent.kt
@@ -1,5 +1,0 @@
-package com.lambda.client.event.events
-
-import com.lambda.client.event.Event
-
-class RealWorldTickEvent : Event

--- a/src/main/kotlin/com/lambda/client/gui/AbstractLambdaGui.kt
+++ b/src/main/kotlin/com/lambda/client/gui/AbstractLambdaGui.kt
@@ -1,6 +1,5 @@
 package com.lambda.client.gui
 
-import com.lambda.client.event.events.RealWorldTickEvent
 import com.lambda.client.event.events.RenderOverlayEvent
 import com.lambda.client.event.listener.listener
 import com.lambda.client.gui.rgui.WindowComponent
@@ -21,6 +20,8 @@ import net.minecraft.client.gui.GuiScreen
 import net.minecraft.client.gui.ScaledResolution
 import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.util.ResourceLocation
+import net.minecraftforge.fml.common.gameevent.TickEvent
+import net.minecraftforge.fml.common.gameevent.TickEvent.ClientTickEvent
 import org.lwjgl.input.Keyboard
 import org.lwjgl.input.Mouse
 import org.lwjgl.opengl.GL11.*
@@ -86,7 +87,8 @@ abstract class AbstractLambdaGui<S : SettingWindow<*>, E : Any> : GuiScreen() {
         mc = Wrapper.minecraft
         windowList.add(ColorPicker)
 
-        listener<RealWorldTickEvent> {
+        listener<ClientTickEvent> {
+            if (it.phase != TickEvent.Phase.END) return@listener
             blurShader.shader?.let { shaderGroup ->
                 val multiplier = ClickGUI.blur * fadeMultiplier
                 shaderGroup.listShaders.forEach { shader ->

--- a/src/main/kotlin/com/lambda/client/gui/AbstractLambdaGui.kt
+++ b/src/main/kotlin/com/lambda/client/gui/AbstractLambdaGui.kt
@@ -232,7 +232,7 @@ abstract class AbstractLambdaGui<S : SettingWindow<*>, E : Any> : GuiScreen() {
         }
     }
 
-    private fun updateWindowOrder() {
+    open fun updateWindowOrder() {
         val cacheList = windowList.sortedBy { it.lastActiveTime }
         windowList.clear()
         windowList.addAll(cacheList)

--- a/src/main/kotlin/com/lambda/client/gui/clickgui/LambdaClickGui.kt
+++ b/src/main/kotlin/com/lambda/client/gui/clickgui/LambdaClickGui.kt
@@ -7,6 +7,7 @@ import com.lambda.client.gui.AbstractLambdaGui
 import com.lambda.client.gui.clickgui.component.*
 import com.lambda.client.gui.clickgui.window.ModuleSettingWindow
 import com.lambda.client.gui.rgui.Component
+import com.lambda.client.gui.rgui.windows.ColorPicker
 import com.lambda.client.gui.rgui.windows.ListWindow
 import com.lambda.client.module.AbstractModule
 import com.lambda.client.module.Category
@@ -74,6 +75,12 @@ object LambdaClickGui : AbstractLambdaGui<ModuleSettingWindow, AbstractModule>()
         setPluginButtonVisibility { true }
         setRemotePluginButtonVisibility { true }
         remotePluginWindow.visible = false
+    }
+
+    override fun updateWindowOrder() {
+        val cacheList = windowList.sortedBy { it.lastActiveTime + if (it is ModuleSettingWindow || it is ColorPicker) 1000000 else 0 }
+        windowList.clear()
+        windowList.addAll(cacheList)
     }
 
     override fun newSettingWindow(element: AbstractModule, mousePos: Vec2f): ModuleSettingWindow {

--- a/src/main/kotlin/com/lambda/client/gui/hudgui/AbstractHudElement.kt
+++ b/src/main/kotlin/com/lambda/client/gui/hudgui/AbstractHudElement.kt
@@ -70,12 +70,12 @@ abstract class AbstractHudElement(
             val currentScreen = mc.currentScreen
             if (currentScreen is GuiChat && !chatSnapping) {
                 val screenH = currentScreen.height
-                if (posY >= screenH - height - 3 && posX <= 3 && yShift == 0.0f) {
+                if (posY >= screenH - height - 3 && yShift == 0.0f) {
                     val prevPosYSnap = posY
                     yShift = -chatSnapY
                     snappedElements.clear()
                     GuiManager.getHudElementOrNull(componentName)?.let { snappedElements.add(it) }
-                    chatSnapCheck(componentName, prevPosYSnap)
+                    chatSnapCheck(componentName, prevPosYSnap, posX, posX + width)
                     chatSnapping = true
                 }
             } else if (currentScreen !is GuiChat && chatSnapping) {
@@ -89,15 +89,16 @@ abstract class AbstractHudElement(
         }
     }
 
-    private fun chatSnapCheck(thisElement: String, prevSnapY: Float) {
+    private fun chatSnapCheck(thisElement: String, prevSnapY: Float, prevSnapXMin: Float, prevSnapXMax: Float) {
         for (element in GuiManager.hudElements) {
             if (!snappedElements.contains(element)
                 && element.componentName != thisElement
                 && element.visible
                 && element.posY + element.height >= prevSnapY - 3
-                && element.posX <= 3) {
+                && element.posX >= prevSnapXMin
+                && element.posX <= prevSnapXMax) {
                 snappedElements.add(element)
-                chatSnapCheck(element.componentName, element.posY)
+                chatSnapCheck(element.componentName, element.posY, element.posX, element.posX + element.width)
                 element.yShift = -chatSnapY
             }
         }

--- a/src/main/kotlin/com/lambda/client/gui/hudgui/LambdaHudGui.kt
+++ b/src/main/kotlin/com/lambda/client/gui/hudgui/LambdaHudGui.kt
@@ -47,6 +47,12 @@ object LambdaHudGui : AbstractLambdaGui<HudSettingWindow, AbstractHudElement>() 
         }
     }
 
+    override fun updateWindowOrder() {
+        val cacheList = windowList.sortedBy { it.lastActiveTime + if (it is AbstractHudElement) 1000000 else 0 }
+        windowList.clear()
+        windowList.addAll(cacheList)
+    }
+
     internal fun register(hudElement: AbstractHudElement) {
         val button = HudButton(hudElement)
         hudWindows[hudElement.category]?.add(button)

--- a/src/main/kotlin/com/lambda/client/gui/rgui/windows/ColorPicker.kt
+++ b/src/main/kotlin/com/lambda/client/gui/rgui/windows/ColorPicker.kt
@@ -85,14 +85,7 @@ object ColorPicker : TitledWindow("Color Picker", 0.0f, 0.0f, 200.0f, 200.0f, Se
 
     override fun onTick() {
         super.onTick()
-        if (visible) {
-            prevHue = hue
-            prevSaturation = saturation
-            prevBrightness = brightness
-            for (component in components) component.onTick()
-            if (hoveredChild != null) updateHSBFromRGB()
-            if (listeningChild?.listening == false) listeningChild = null
-        }
+        for (component in components) component.onTick()
     }
 
     override fun onMouseInput(mousePos: Vec2f) {
@@ -170,6 +163,14 @@ object ColorPicker : TitledWindow("Color Picker", 0.0f, 0.0f, 200.0f, 200.0f, Se
     override fun onRender(vertexHelper: VertexHelper, absolutePos: Vec2f) {
         super.onRender(vertexHelper, absolutePos)
 
+        if (visible) {
+            prevHue = hue
+            prevSaturation = saturation
+            prevBrightness = brightness
+            if (hoveredChild != null) updateHSBFromRGB()
+            if (listeningChild?.listening == false) listeningChild = null
+        }
+
         drawColorField(vertexHelper)
         drawHueSlider(vertexHelper)
         drawColorPreview(vertexHelper)
@@ -200,8 +201,7 @@ object ColorPicker : TitledWindow("Color Picker", 0.0f, 0.0f, 200.0f, 200.0f, Se
         GlStateManager.tryBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE)
 
         // Saturation
-        val interpolatedHue = prevHue + (hue - prevHue) * mc.renderPartialTicks
-        val rightColor = ColorHolder(Color.getHSBColor(interpolatedHue, 1.0f, 1.0f))
+        val rightColor = ColorHolder(Color.getHSBColor(hue, 1.0f, 1.0f))
         val leftColor = ColorHolder(255, 255, 255)
         vertexHelper.begin(GL_TRIANGLE_STRIP)
         vertexHelper.put(fieldPos.first.toVec2d(), leftColor) // Top left
@@ -227,11 +227,9 @@ object ColorPicker : TitledWindow("Color Picker", 0.0f, 0.0f, 200.0f, 200.0f, Se
         if (ClickGUI.windowOutline) RenderUtils2D.drawRectOutline(vertexHelper, fieldPos.first.toVec2d(), fieldPos.second.toVec2d(), ClickGUI.outlineWidth, GuiColors.outline)
 
         // Circle pointer
-        val interpolatedSaturation = prevSaturation + (saturation - prevSaturation) * mc.renderPartialTicks
-        val interpolatedBrightness = prevBrightness + (brightness - prevBrightness) * mc.renderPartialTicks
-        val relativeBrightness = ((1.0f - (1.0f - interpolatedSaturation) * interpolatedBrightness) * 255.0f).toInt()
+        val relativeBrightness = ((1.0f - (1.0f - saturation) * brightness) * 255.0f).toInt()
         val circleColor = ColorHolder(relativeBrightness, relativeBrightness, relativeBrightness)
-        val circlePos = Vec2d((fieldPos.first.x + fieldHeight * interpolatedSaturation).toDouble(), fieldPos.first.y + fieldHeight * (1.0 - interpolatedBrightness))
+        val circlePos = Vec2d((fieldPos.first.x + fieldHeight * saturation).toDouble(), fieldPos.first.y + fieldHeight * (1.0 - brightness))
         RenderUtils2D.drawCircleOutline(vertexHelper, circlePos, 4.0, 32, 1.5f, circleColor)
     }
 

--- a/src/main/kotlin/com/lambda/client/gui/rgui/windows/ListWindow.kt
+++ b/src/main/kotlin/com/lambda/client/gui/rgui/windows/ListWindow.kt
@@ -213,7 +213,7 @@ open class ListWindow(
     override fun onMouseInput(mousePos: Vec2f) {
         super.onMouseInput(mousePos)
         val relativeMousePos = mousePos.minus(posX, posY - renderScrollProgress)
-        updateHovered(relativeMousePos)
+        if (mouseState != MouseState.DRAG) updateHovered(relativeMousePos)
         if (Mouse.getEventDWheel() != 0) {
             scrollTimer.reset()
             scrollSpeed -= Mouse.getEventDWheel() * 0.1f

--- a/src/main/kotlin/com/lambda/client/gui/rgui/windows/ListWindow.kt
+++ b/src/main/kotlin/com/lambda/client/gui/rgui/windows/ListWindow.kt
@@ -13,6 +13,7 @@ import com.lambda.client.util.graphics.GlStateUtils
 import com.lambda.client.util.graphics.VertexHelper
 import com.lambda.client.util.graphics.font.FontRenderAdapter
 import com.lambda.client.util.math.Vec2f
+import net.minecraft.client.Minecraft
 import org.lwjgl.input.Mouse
 import org.lwjgl.opengl.GL11.*
 import kotlin.math.max
@@ -54,7 +55,7 @@ open class ListWindow(
         }
     var prevScrollProgress = 0.0f
     private val renderScrollProgress
-        get() = prevScrollProgress + (scrollProgress - prevScrollProgress) * mc.renderPartialTicks
+        get() = prevScrollProgress + (scrollProgress - prevScrollProgress)
 
     private var doubleClickTime = -1L
 
@@ -125,8 +126,11 @@ open class ListWindow(
 
     override fun onTick() {
         super.onTick()
-        if (children.isEmpty()) return
+        children.forEach { it.onTick() }
+    }
 
+    override fun onRender(vertexHelper: VertexHelper, absolutePos: Vec2f) {
+        super.onRender(vertexHelper, absolutePos)
         val lastVisible = children.lastOrNull { it.visible }
         val maxScrollProgress = lastVisible?.let { max(it.posY + it.height + ClickGUI.verticalMargin + ClickGUI.resizeBar - height, 0.01f) }
             ?: draggableHeight
@@ -142,18 +146,12 @@ open class ListWindow(
 
         if (scrollTimer.tick(100L, false)) {
             if (scrollProgress < 0) {
-                scrollSpeed = scrollProgress * -ClickGUI.scrollRubberbandSpeed
+                scrollSpeed = scrollProgress * -(ClickGUI.scrollRubberbandSpeed / (max(Minecraft.getDebugFPS(), 30) / 60f))
             } else if (scrollProgress > maxScrollProgress) {
-                scrollSpeed = (scrollProgress - maxScrollProgress) * -ClickGUI.scrollRubberbandSpeed
+                scrollSpeed = (scrollProgress - maxScrollProgress) * -(ClickGUI.scrollRubberbandSpeed / (max(Minecraft.getDebugFPS(), 30) / 60f))
             }
         }
-
         updateChild()
-        children.forEach { it.onTick() }
-    }
-
-    override fun onRender(vertexHelper: VertexHelper, absolutePos: Vec2f) {
-        super.onRender(vertexHelper, absolutePos)
 
         if (drawHandle) {
             val handleText = "....."


### PR DESCRIPTION
1. Decoupled animation scroll rubberbanding animation from ticks. fixes stuttery animation. tbh i'd rather just remove this animation entirely but its smoother now. 
2. Fixed similar animation stuttering in color picker updates tied to ticks.
3. Removed RealWorldTickEvent as all render events/animations are no longer tied to the tick event. at least all I've found...
4. Prevent module setting windows from going behind other windows
5. Prevent hud elements from going behind hud editor list windows
6. Removed X check from HUD chat snapping. The chat GUI actually extends across the entire screen so idk why I added this in the first place. 