### PR TITLE
Module Hold Binds

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/AbstractModule.kt
+++ b/src/main/kotlin/com/lambda/client/module/AbstractModule.kt
@@ -12,9 +12,15 @@ import com.lambda.client.setting.settings.SettingRegister
 import com.lambda.client.setting.settings.impl.number.IntegerSetting
 import com.lambda.client.setting.settings.impl.other.BindSetting
 import com.lambda.client.setting.settings.impl.primitive.BooleanSetting
+import com.lambda.client.setting.settings.impl.primitive.EnumSetting
 import com.lambda.client.util.Bind
 import com.lambda.client.util.text.MessageSendHelper
+import com.lambda.client.util.threads.safeListener
 import net.minecraft.client.Minecraft
+import net.minecraftforge.fml.common.gameevent.TickEvent
+import net.minecraftforge.fml.common.gameevent.TickEvent.ClientTickEvent
+import org.lwjgl.input.Keyboard
+import org.lwjgl.input.Mouse
 
 @Suppress("UNCHECKED_CAST")
 abstract class AbstractModule(
@@ -31,11 +37,15 @@ abstract class AbstractModule(
 ) : Nameable, Alias, SettingRegister<Nameable> by config as NameableConfig<Nameable> {
 
     val bind = BindSetting("Bind", Bind(), { !alwaysEnabled }).also(::addSetting)
+    private val toggleMode = EnumSetting("Toggle Mode", ToggleMode.TOGGLE).also(::addSetting)
     private val enabled = BooleanSetting("Enabled", false, { false }).also(::addSetting)
     private val visible = BooleanSetting("Visible", showOnArray).also(::addSetting)
     private val default = BooleanSetting("Default", false, { settingList.isNotEmpty() }).also(::addSetting)
     val priorityForGui = IntegerSetting("Priority In GUI", 0, 0..1000, 50, { ClickGUI.sortBy.value == ClickGUI.SortByOptions.CUSTOM }, fineStep = 1).also(::addSetting)
     val clicks = IntegerSetting("Clicks", 0, 0..Int.MAX_VALUE, 1, { false }).also(::addSetting) // Not nice, however easiest way to save it.
+    enum class ToggleMode {
+        TOGGLE, HOLD
+    }
 
     val fullSettingList get() = (config as NameableConfig<Nameable>).getSettings(this)
     val settingList: List<AbstractSetting<*>> get() = fullSettingList.filter { it != bind && it != enabled && it != visible && it != default && it != clicks }
@@ -138,6 +148,15 @@ abstract class AbstractModule(
         priorityForGui.listeners.add { LambdaClickGui.reorderModules() }
 
         // clicks is deliberately not re-organised when changed.
+
+        safeListener<ClientTickEvent> {
+            if (it.phase != TickEvent.Phase.START || bind.value.isEmpty || toggleMode.value != ToggleMode.HOLD) return@safeListener
+            bind.value.mouseKey?.let {
+                if (!Mouse.isButtonDown(it-1)) toggle()
+            } ?: run {
+                if (!Keyboard.isKeyDown(bind.value.key)) toggle()
+            }
+        }
     }
 
     protected companion object {


### PR DESCRIPTION
**Describe the pull**
Module binds that are only enabled while the bind key is held down.

**Describe how this pull is helpful**
Useful for modules like freelook, speed, step, etc.
