### PR TITLE
Fix baritone #click drag selection

### DIFF
--- a/src/main/kotlin/com/lambda/client/LambdaMod.kt
+++ b/src/main/kotlin/com/lambda/client/LambdaMod.kt
@@ -63,6 +63,11 @@ class LambdaMod {
     fun init(event: FMLInitializationEvent) {
         LOG.info("Initializing $NAME $VERSION")
 
+        // load this class so that baritone doesn't crash
+        // see https://github.com/cabaletta/baritone/issues/3859
+        @Suppress("UNUSED_VARIABLE")
+        val baritoneTroll = baritone.api.utils.BetterBlockPos::class.java
+
         LoaderWrapper.loadAll()
 
         MinecraftForge.EVENT_BUS.register(ForgeEventProcessor)


### PR DESCRIPTION
**Describe the pull**
See https://github.com/cabaletta/baritone/issues/3859
Resolves #561 

**Describe how this pull is helpful**
Fixes baritone crashes related to BetterBlockPos class mapping shenanigans

**Additional context**
#click is a quick way to test. Crashes reliably for me without this patch.
