### PR TITLE
2b2t efly anti kick and Align Coords

### DIFF
--- a/src/main/kotlin/com/lambda/client/gui/hudgui/elements/world/Coordinates.kt
+++ b/src/main/kotlin/com/lambda/client/gui/hudgui/elements/world/Coordinates.kt
@@ -21,6 +21,7 @@ internal object Coordinates : LabelHud(
     private val showNetherOverworldMultiline by setting("Show Nether/Overworld Multiline", false, { showNetherOverworld })
     private val decimalPlaces by setting("Decimal Places", 1, 0..4, 1)
     private val thousandsSeparator by setting("Thousands Separator", false)
+    private val alignCoords by setting("Align Coords", false, description = "Align your coords to the center of the block")
 
     private val netherToOverworld = Vec3d(8.0, 1.0, 8.0)
     private val overworldToNether = Vec3d(0.125, 1.0, 0.125)
@@ -51,9 +52,13 @@ internal object Coordinates : LabelHud(
 
     private fun getFormattedCoords(pos: Vec3d, brackets: Boolean = false): TextComponent.TextElement {
         if (!showX && !showY && !showZ) return TextComponent.TextElement("", primaryColor)
-        val x = roundOrInt(pos.x)
+        val alignValue = when {
+            alignCoords -> 0.5f
+            else -> 0.0f
+        }
+        val x = roundOrInt(pos.x-alignValue)
         val y = roundOrInt(pos.y)
-        val z = roundOrInt(pos.z)
+        val z = roundOrInt(pos.z-alignValue)
         return StringBuilder().run {
             if (brackets) append("[")
             if (showX) append(x)


### PR DESCRIPTION
**Describe the pull**
<!-- A clear and concise description of what the pull is for. -->
Fixes the broken elytra detector, disables 2b2t efly if there is packet spam. Adds a coord aligner.

**Describe how this pull is helpful**
<!-- A clear description of why this should be merged -->
Helps you get kicked less from 2b2t. Also this PR can point coords to the center of blocks instead of the edge.

**Additional context**
<!-- Add any other context about the pull here. -->
This pull request is rushed because of the update and likely has bugs. 